### PR TITLE
Removed everything related to nexus.

### DIFF
--- a/micronautpi4j-utils/build.gradle
+++ b/micronautpi4j-utils/build.gradle
@@ -4,14 +4,14 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
-     id('io.github.gradle-nexus.publish-plugin') version '1.1.0'
+//     id('io.github.gradle-nexus.publish-plugin') version '1.1.0'
 }
 
 group = 'io.github.oss-slu'
 version = 'v1.0.0'
 
 apply plugin: 'maven-publish'
-apply plugin: 'io.github.gradle-nexus.publish-plugin'
+//apply plugin: 'io.github.gradle-nexus.publish-plugin'
 
 repositories {
     mavenCentral()
@@ -42,6 +42,7 @@ asciidoctor{
     baseDirFollowsSourceDir()
 }
 
+/*
 nexusPublishing{
     repositories {
         sonatype{
@@ -51,7 +52,7 @@ nexusPublishing{
         }
     }
 }
-
+*/
 ext.genOutputDir = file("$buildDir/generated-resources")
 
 task generateVersionTxt()  {


### PR DESCRIPTION
Fixing the building of the docs: as suggested by @GreihMurray I removed references to nexus from the micronautpi4j-utils/build.gradle. Manually running: gradlew asciidoctor now works on my clone of the repo.