### PR TITLE
Javadoc workflow to deploy to gh-pages. Closes Issue #150

### DIFF
--- a/.github/workflows/javadoc-build.yml
+++ b/.github/workflows/javadoc-build.yml
@@ -1,10 +1,9 @@
-name: build javadocs
+name: Build Javadoc
 
 on:
   push:
     branches:
       - main
-      - develop
       - yamlDocs
 jobs:
   javadoc_build:
@@ -13,14 +12,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-          #I think above and below are correct. The build container portion is what I need to figure out. 
-      #- name: Get build container
-       # id: adocbuild
-        #uses: tonynv/asciidoctor-action@master
-        #with:
-         # program: "./gradlew asciidoctor"
-      - name: Deploy docs to ghpages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Deploy Javadoc
+        id: javadoc_build
+        uses: MathieuSoysal/Javadoc-publisher.yml@v2.5.0
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_branch: gh-pages

--- a/.github/workflows/javadoc-build.yml
+++ b/.github/workflows/javadoc-build.yml
@@ -1,0 +1,28 @@
+name: build javadocs
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - yamlDocs
+jobs:
+  javadoc_build:
+    runs-on: ubuntu-latest
+    name: Building the javadocs to html.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+          #I think above and below are correct. The build container portion is what I need to figure out. 
+      #- name: Get build container
+       # id: adocbuild
+        #uses: tonynv/asciidoctor-action@master
+        #with:
+         # program: "./gradlew asciidoctor"
+      - name: Deploy docs to ghpages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          publish_branch: gh-pages
+          publish_dir: ./micronautpi4j-utils/build/docs/javadoc/
+


### PR DESCRIPTION
The yml file at, .github/workflows/javadoc-build.yml, builds the javadocs to html then deploys it to the gh-pages branch so users can view the javadocs. 