### PR TITLE
Includes javadocs in the gh-pages branch

### DIFF
--- a/pi4micronaut-utils/build.gradle
+++ b/pi4micronaut-utils/build.gradle
@@ -42,6 +42,9 @@ asciidoctor {
         from(sourceDir) {
             include 'img/**'
         }
+        from("${sourceDir}/../") {
+            include 'javadoc/**'
+        }
     }
 }
 

--- a/pi4micronaut-utils/src/docs/asciidoc/index.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/index.adoc
@@ -16,7 +16,7 @@
 toc::[]
 
 [.text-right]
-https://oss-slu.github.io/Pi4Micronaut/javadoc/index.html[API References]
+ ../javadoc/index.html[API References]
 
 include::introduction.adoc[]
 

--- a/pi4micronaut-utils/src/docs/asciidoc/index.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/index.adoc
@@ -16,7 +16,7 @@
 toc::[]
 
 [.text-right]
- ../javadoc/index.html[API References]
+/javadoc/index.html[API References]
 
 include::introduction.adoc[]
 

--- a/pi4micronaut-utils/src/docs/asciidoc/index.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/index.adoc
@@ -16,7 +16,7 @@
 toc::[]
 
 [.text-right]
-/javadoc/index.html[API References]
+https://oss-slu.github.io/Pi4Micronaut/javadoc/index.html[API References]
 
 include::introduction.adoc[]
 


### PR DESCRIPTION
Adds the javadoc files to the gh-pages branch. I have not tested this. It also does not automatically generate the javadoc files.