### PR TITLE
249 push button helper tests

### DIFF
--- a/pi4micronaut-utils/build.gradle
+++ b/pi4micronaut-utils/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     api 'com.pi4j:pi4j-core:2.4.0'
     api 'com.pi4j:pi4j-plugin-raspberrypi:2.4.0'
     api 'com.pi4j:pi4j-plugin-pigpio:2.4.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 }
 
@@ -164,6 +167,14 @@ publishing {
     signing {
         useInMemoryPgpKeys(System.getenv('GPG_KEY'), System.getenv('GPG_PASSWORD'))
         sign publishing.publications.mavenJava
+    }
+
+    test{
+        useJUnitPlatform()
+        testLogging {
+            events "passed", "skipped", "failed"
+        }
+
     }
 }
 

--- a/pi4micronaut-utils/src/docs/javadoc/legal/COPYRIGHT
+++ b/pi4micronaut-utils/src/docs/javadoc/legal/COPYRIGHT
@@ -1,1 +1,69 @@
-Please see ..\java.base\COPYRIGHT
+Copyright © 1993, 2018, Oracle and/or its affiliates.
+All rights reserved.
+
+This software and related documentation are provided under a
+license agreement containing restrictions on use and
+disclosure and are protected by intellectual property laws.
+Except as expressly permitted in your license agreement or
+allowed by law, you may not use, copy, reproduce, translate,
+broadcast, modify, license, transmit, distribute, exhibit,
+perform, publish, or display any part, in any form, or by
+any means. Reverse engineering, disassembly, or
+decompilation of this software, unless required by law for
+interoperability, is prohibited.
+
+The information contained herein is subject to change
+without notice and is not warranted to be error-free. If you
+find any errors, please report them to us in writing.
+
+If this is software or related documentation that is
+delivered to the U.S. Government or anyone licensing it on
+behalf of the U.S. Government, the following notice is
+applicable:
+
+U.S. GOVERNMENT END USERS: Oracle programs, including any
+operating system, integrated software, any programs
+installed on the hardware, and/or documentation, delivered
+to U.S. Government end users are "commercial computer
+software" pursuant to the applicable Federal Acquisition
+Regulation and agency-specific supplemental regulations. As
+such, use, duplication, disclosure, modification, and
+adaptation of the programs, including any operating system,
+integrated software, any programs installed on the hardware,
+and/or documentation, shall be subject to license terms and
+license restrictions applicable to the programs. No other
+rights are granted to the U.S. Government.
+
+This software or hardware is developed for general use in a
+variety of information management applications. It is not
+developed or intended for use in any inherently dangerous
+applications, including applications that may create a risk
+of personal injury. If you use this software or hardware in
+dangerous applications, then you shall be responsible to
+take all appropriate fail-safe, backup, redundancy, and
+other measures to ensure its safe use. Oracle Corporation
+and its affiliates disclaim any liability for any damages
+caused by use of this software or hardware in dangerous
+applications.
+
+Oracle and Java are registered trademarks of Oracle and/or
+its affiliates. Other names may be trademarks of their
+respective owners.
+
+Intel and Intel Xeon are trademarks or registered trademarks
+of Intel Corporation. All SPARC trademarks are used under
+license and are trademarks or registered trademarks of SPARC
+International, Inc. AMD, Opteron, the AMD logo, and the AMD
+Opteron logo are trademarks or registered trademarks of
+Advanced Micro Devices. UNIX is a registered trademark of
+The Open Group.
+
+This software or hardware and documentation may provide
+access to or information on content, products, and services
+from third parties. Oracle Corporation and its affiliates
+are not responsible for and expressly disclaim all
+warranties of any kind with respect to third-party content,
+products, and services. Oracle Corporation and its
+affiliates will not be responsible for any loss, costs, or
+damages incurred due to your access to or use of third-party
+content, products, or services.

--- a/pi4micronaut-utils/src/docs/javadoc/legal/LICENSE
+++ b/pi4micronaut-utils/src/docs/javadoc/legal/LICENSE
@@ -1,1 +1,118 @@
-Please see ..\java.base\LICENSE
+Your use of this Program is governed by the No-Fee Terms and Conditions set
+forth below, unless you have received this Program (alone or as part of another
+Oracle product) under an Oracle license agreement (including but not limited to
+the Oracle Master Agreement), in which case your use of this Program is governed
+solely by such license agreement with Oracle.
+
+Oracle No-Fee Terms and Conditions (NFTC)
+
+Definitions
+
+"Oracle" refers to Oracle America, Inc. "You" and "Your" refers to (a) a company
+or organization (each an "Entity") accessing the Programs, if use of the
+Programs will be on behalf of such Entity; or (b) an individual accessing the
+Programs, if use of the Programs will not be on behalf of an Entity.
+"Program(s)" refers to Oracle software provided by Oracle pursuant to the
+following terms and any updates, error corrections, and/or Program Documentation
+provided by Oracle. "Program Documentation" refers to Program user manuals and
+Program installation manuals, if any. If available, Program Documentation may be
+delivered with the Programs and/or may be accessed from
+www.oracle.com/documentation. "Separate Terms" refers to separate license terms
+that are specified in the Program Documentation, readmes or notice files and
+that apply to Separately Licensed Technology. "Separately Licensed Technology"
+refers to Oracle or third party technology that is licensed under Separate Terms
+and not under the terms of this license.
+
+Separately Licensed Technology
+
+Oracle may provide certain notices to You in Program Documentation, readmes or
+notice files in connection with Oracle or third party technology provided as or
+with the Programs. If specified in the Program Documentation, readmes or notice
+files, such technology will be licensed to You under Separate Terms. Your rights
+to use Separately Licensed Technology under Separate Terms are not restricted in
+any way by the terms herein. For clarity, notwithstanding the existence of a
+notice, third party technology that is not Separately Licensed Technology shall
+be deemed part of the Programs licensed to You under the terms of this license.
+
+Source Code for Open Source Software
+
+For software that You receive from Oracle in binary form that is licensed under
+an open source license that gives You the right to receive the source code for
+that binary, You can obtain a copy of the applicable source code from
+https://oss.oracle.com/sources/ or http://www.oracle.com/goto/opensourcecode. If
+the source code for such software was not provided to You with the binary, You
+can also receive a copy of the source code on physical media by submitting a
+written request pursuant to the instructions in the "Written Offer for Source
+Code" section of the latter website.
+
+-------------------------------------------------------------------------------
+
+The following license terms apply to those Programs that are not provided to You
+under Separate Terms.
+
+License Rights and Restrictions
+
+Oracle grants to You, as a recipient of this Program, subject to the conditions
+stated herein, a nonexclusive, nontransferable, limited license to:
+
+(a) internally use the unmodified Programs for the purposes of developing,
+testing, prototyping and demonstrating your applications, and running the
+Program for Your own personal use or internal business operations; and
+
+(b) redistribute the unmodified Program and Program Documentation, under the
+terms of this License, provided that You do not charge Your licensees any fees
+associated with such distribution or use of the Program, including, without
+limitation, fees for products that include or are bundled with a copy of the
+Program or for services that involve the use of the distributed Program.
+
+You may make copies of the Programs to the extent reasonably necessary for
+exercising the license rights granted herein and for backup purposes. You are
+granted the right to use the Programs to provide third party training in the use
+of the Programs and associated Separately Licensed Technology only if there is
+express authorization of such use by Oracle on the Program's download page or in
+the Program Documentation.
+
+Your license is contingent on compliance with the following conditions:
+
+- You do not remove markings or notices of either Oracle's or a licensor's
+  proprietary rights from the Programs or Program Documentation;
+
+- You comply with all U.S. and applicable export control and economic sanctions
+  laws and regulations that govern Your use of the Programs (including technical
+  data);
+
+- You do not cause or permit reverse engineering, disassembly or decompilation
+  of the Programs (except as allowed by law) by You nor allow an associated
+  party to do so.
+
+For clarity, any source code that may be included in the distribution with the
+Programs is provided solely for reference purposes and may not be modified,
+unless such source code is under Separate Terms permitting modification.
+
+Ownership
+
+Oracle or its licensors retain all ownership and intellectual property rights to
+the Programs.
+
+Information Collection
+
+The Programs' installation and/or auto-update processes, if any, may transmit a
+limited amount of data to Oracle or its service provider about those processes
+to help Oracle understand and optimize them. Oracle does not associate the data
+with personally identifiable information. Refer to Oracle's Privacy Policy at
+www.oracle.com/privacy.
+
+Disclaimer of Warranties; Limitation of Liability
+
+THE PROGRAMS ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND. ORACLE FURTHER
+DISCLAIMS ALL WARRANTIES, EXPRESS AND IMPLIED, INCLUDING WITHOUT LIMITATION, ANY
+IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR
+NONINFRINGEMENT.
+
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW WILL ORACLE BE LIABLE TO YOU FOR
+DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES
+ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT
+LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.

--- a/pi4micronaut-utils/src/test/java/com/opensourcewithslu/inputdevices/MockDigitalInput.java
+++ b/pi4micronaut-utils/src/test/java/com/opensourcewithslu/inputdevices/MockDigitalInput.java
@@ -1,0 +1,96 @@
+package com.opensourcewithslu.inputdevices;
+import com.pi4j.common.Metadata;
+import com.pi4j.context.Context;
+import com.pi4j.exception.InitializeException;
+import com.pi4j.exception.ShutdownException;
+import com.pi4j.io.binding.DigitalBinding;
+import com.pi4j.io.gpio.digital.*;
+
+public class MockDigitalInput implements DigitalInput {
+    DigitalState mockState;
+    public MockDigitalInput(){
+        mockState = DigitalState.UNKNOWN;
+    }
+    public void SetState(DigitalState fakeState) {
+        mockState = fakeState;
+    }
+    @Override
+    public DigitalState state() {
+        return mockState;
+    }
+
+    @Override
+    public DigitalInput addListener(DigitalStateChangeListener... digitalStateChangeListeners) {
+        return null;
+    }
+
+    @Override
+    public DigitalInput removeListener(DigitalStateChangeListener... digitalStateChangeListeners) {
+        return null;
+    }
+
+    @Override
+    public boolean isOn() {
+        return false;
+    }
+
+    @Override
+    public DigitalInput bind(DigitalBinding... digitalBindings) {
+        return null;
+    }
+
+    @Override
+    public DigitalInput unbind(DigitalBinding... digitalBindings) {
+        return null;
+    }
+
+    @Override
+    public DigitalInputConfig config() {
+        return null;
+    }
+
+    @Override
+    public DigitalInput name(String s) {
+        return null;
+    }
+
+    @Override
+    public DigitalInput description(String s) {
+        return null;
+    }
+
+    @Override
+    public DigitalInputProvider provider() {
+        return null;
+    }
+
+    @Override
+    public String id() {
+        return "";
+    }
+
+    @Override
+    public String name() {
+        return "";
+    }
+
+    @Override
+    public String description() {
+        return "";
+    }
+
+    @Override
+    public Metadata metadata() {
+        return null;
+    }
+
+    @Override
+    public Object initialize(Context context) throws InitializeException {
+        return null;
+    }
+
+    @Override
+    public Object shutdown(Context context) throws ShutdownException {
+        return null;
+    }
+}

--- a/pi4micronaut-utils/src/test/java/com/opensourcewithslu/inputdevices/PushButtonHelperTests.java
+++ b/pi4micronaut-utils/src/test/java/com/opensourcewithslu/inputdevices/PushButtonHelperTests.java
@@ -1,0 +1,27 @@
+package com.opensourcewithslu.inputdevices;
+
+import static org.junit.jupiter.api.Assertions.*;
+import com.pi4j.io.gpio.digital.*;
+
+class PushButtonHelperTests {
+
+    @org.junit.jupiter.api.Test
+    void initializeStateLow() {
+        MockDigitalInput input = new MockDigitalInput();
+        input.SetState(DigitalState.LOW);
+        PushButtonHelper helper = new PushButtonHelper(input);
+        assertFalse(helper.isPressed);
+    }
+
+    @org.junit.jupiter.api.Test
+    void initializeStateHigh() {
+        MockDigitalInput input = new MockDigitalInput();
+        input.SetState(DigitalState.HIGH);
+        PushButtonHelper helper = new PushButtonHelper(input);
+        assertTrue(helper.isPressed);
+    }
+
+    @org.junit.jupiter.api.Test
+    void addEventListener() {
+    }
+}

--- a/pi4micronaut-utils/src/test/java/com/opensourcewithslu/inputdevices/PushButtonHelperTests.java
+++ b/pi4micronaut-utils/src/test/java/com/opensourcewithslu/inputdevices/PushButtonHelperTests.java
@@ -1,27 +1,43 @@
 package com.opensourcewithslu.inputdevices;
 
 import static org.junit.jupiter.api.Assertions.*;
+
+import com.opensourcewithslu.mock.MockDigitalInput;
 import com.pi4j.io.gpio.digital.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class PushButtonHelperTests {
 
     @org.junit.jupiter.api.Test
+    /* This test simulates the push button in a LOW state without connecting to the actual hardware.
+    It ensures that when the button input is LOW, the 'isPressed' state is correctly identified as false.
+     */
     void initializeStateLow() {
-        MockDigitalInput input = new MockDigitalInput();
-        input.SetState(DigitalState.LOW);
-        PushButtonHelper helper = new PushButtonHelper(input);
-        assertFalse(helper.isPressed);
+        Logger log = LoggerFactory.getLogger(PushButtonHelper.class); //
+        MockDigitalInput input = new MockDigitalInput(); // Mock input for the button
+        input.SetState(DigitalState.LOW); // Simulate button in the LOW state
+        PushButtonHelper helper = new PushButtonHelper(input); //
+        assertFalse(helper.isPressed); // Button is not pressed when input is LOW
     }
 
     @org.junit.jupiter.api.Test
+    /*
+    This test simulates the push button in a HIGH state.
+    It verifies that when the button input is HIGH, the 'IsPressed' state is correctly identified as true.
+     */
     void initializeStateHigh() {
         MockDigitalInput input = new MockDigitalInput();
-        input.SetState(DigitalState.HIGH);
+        input.SetState(DigitalState.HIGH); // Simulate button in the HIGH state
         PushButtonHelper helper = new PushButtonHelper(input);
-        assertTrue(helper.isPressed);
+        assertTrue(helper.isPressed); // Button is pressed when input is HIGH
     }
 
     @org.junit.jupiter.api.Test
+    /*
+        Placeholder for testing even listener functionality.
+         */
     void addEventListener() {
+
     }
 }

--- a/pi4micronaut-utils/src/test/java/com/opensourcewithslu/mock/MockDigitalInput.java
+++ b/pi4micronaut-utils/src/test/java/com/opensourcewithslu/mock/MockDigitalInput.java
@@ -1,4 +1,4 @@
-package com.opensourcewithslu.inputdevices;
+package com.opensourcewithslu.mock;
 import com.pi4j.common.Metadata;
 import com.pi4j.context.Context;
 import com.pi4j.exception.InitializeException;
@@ -6,6 +6,13 @@ import com.pi4j.exception.ShutdownException;
 import com.pi4j.io.binding.DigitalBinding;
 import com.pi4j.io.gpio.digital.*;
 
+/*
+The ockDigitalInput class implements the DigitalInput interface, which requires
+all methods to be implemented, even if they are not used in the mock.
+These methods have default or no operation implementations to fulfill the interface contract.
+they provided an empty method("return null") because the methods are required by the interface,
+yet for the mock implementation, it doesn't need to do anything.
+*/
 public class MockDigitalInput implements DigitalInput {
     DigitalState mockState;
     public MockDigitalInput(){
@@ -71,7 +78,7 @@ public class MockDigitalInput implements DigitalInput {
 
     @Override
     public String name() {
-        return "";
+        return "MockDigitalInput";
     }
 
     @Override


### PR DESCRIPTION
Fixes #249 

Updated the gradle build for JUnit.

Added unit tests for PushButtonHelper initialization.

This issue was needed to change because it involves setting up and verifying fundamental functionality, which makes it suitable for newcomers.

Created an instance of the class named MOckDigitalInput to simulates the behavior of a real object in controlled ways, without needing the real hardware or dependencies. Hence, it mimics the behavior of a real digital input device, such as a push button connected to a Raspberry Pi's GPIO pins. Tested the case isPressed to simulate different conditions like the button being pressed or not by setting specific states that created: DigitalState.LOW or DigitalState.HIGH.