### PR TITLE
4 Digit 7 Segment Display

### DIFF
--- a/components/src/main/java/com/opensourcewithslu/components/controllers/FourDigitSevenSegmentDisplayController.java
+++ b/components/src/main/java/com/opensourcewithslu/components/controllers/FourDigitSevenSegmentDisplayController.java
@@ -31,14 +31,24 @@ public class FourDigitSevenSegmentDisplayController {
         displayHelper.disable();
     }
 
-    @Get("/displayValue/{value}")
-    public void displayValue(String value) {
-        displayHelper.displayValue(value);
+    @Get("/print/{value}")
+    public void print(String value) {
+        displayHelper.print(value);
     }
 
     @Get("/clear")
-    public void clearDisplay() {
+    public void clear() {
         displayHelper.clear();
+    }
+
+    @Get("set-digit/{digit}/{value}")
+    public void setDigit(int digit, char value) {
+        displayHelper.setDigit(digit, value);
+    }
+
+    @Get("set-decimal-point/{digit}/{value}")
+    public void setDecimalPoint(int digit, boolean value) {
+        displayHelper.setDecimalPoint(digit, value);
     }
 }
 //end::ex[]

--- a/pi4micronaut-utils/src/docs/asciidoc/components/outputComponents/fourDigitSevenSegment.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/outputComponents/fourDigitSevenSegment.adoc
@@ -123,11 +123,49 @@ $ curl http://localhost:8080/four-digit-seven-segment/displayValue/1%2034
 
 [source,yaml]
 ----
-i2c:
-four-digit-seven-segment:
-  name: 4 Digit 7 Segment Display
-  bus: 1
-  device: 0x27
+digital-output:
+  digit-0:
+    name: Digit 0
+    address: 17
+    shutdown: LOW
+    initial: LOW
+    provider: pigpio-digital-output
+  digit-1:
+    name: Digit 1
+    address: 27
+    shutdown: LOW
+    initial: LOW
+    provider: pigpio-digital-output
+  digit-2:
+    name: Digit 2
+    address: 22
+    shutdown: LOW
+    initial: LOW
+    provider: pigpio-digital-output
+  digit-3:
+    name: Digit 3
+    address: 10
+    shutdown: LOW
+    initial: LOW
+    provider: pigpio-digital-output
+  sdi:
+    name: SDI
+    address: 24
+    shutdown: LOW
+    initial: LOW
+    provider: pigpio-digital-output
+  rclk:
+    name: RCLK
+    address: 23
+    shutdown: LOW
+    initial: LOW
+    provider: pigpio-digital-output
+  srclk:
+    name: SRCLK
+    address: 18
+    shutdown: LOW
+    initial: LOW
+    provider: pigpio-digital-output
 ----
 
 ===== Constructor and Methods

--- a/pi4micronaut-utils/src/docs/asciidoc/components/outputComponents/fourDigitSevenSegment.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/outputComponents/fourDigitSevenSegment.adoc
@@ -36,14 +36,31 @@ This section provides details of the 4-digit 7-segment display, including its co
 * Place the four resistors on the breadboard.
 * Place the 4-digit 7-segment display on the breadboard.
 * Connect a jumper wire from each "digit" pin of the 4-digit 7-segment to one of the resistors.
-* Connect the other end of the resistors to the Raspberry Pi's pins:
+* Connect the other ends of the resistors to the Raspberry Pi's pins:
 
-- Digit 1 to GPIO17 (BCM pin 18)
-- Digit 2 to GPIO27 (BCM pin 27)
-- Digit 3 to GPIO22 (BCM pin 22)
-- Digit 4 to SPIMOSI (BCM pin 10)
+- Digit 1 (pin 12) to GPIO17 (BCM pin 18)
+- Digit 2 (pin 9) to GPIO27 (BCM pin 27)
+- Digit 3 (pin 8) to GPIO22 (BCM pin 22)
+- Digit 4 (pin 6) to SPIMOSI (BCM pin 10)
 
-// TODO: Describe connections to 74HC595
+* Use jumper wires to connect pins on the display to pins on the 74HC595:
+
+- A (pin 11) to Q0 (pin 15)
+- B (pin 7) to Q1 (pin 1)
+- C (pin 4) to Q2 (pin 2)
+- D (pin 2) to Q3 (pin 3)
+- E (pin 1) to Q4 (pin 4)
+- F (pin 10) to Q5 (pin 5)
+- G (pin 5) to Q6 (pin 6)
+- DP (pin 3) to Q7 (pin 7)
+
+* Use jumper wires to connect the 74HC595 to the Raspberry Pi:
+
+- SHcp (pin 11) to GPIO18 (BCM pin 18)
+- STcp (pin 12) to GPIO23 (BCM pin 23)
+- DS (pin 14) to GPIO24 (BCM pin 24)
+
+* Use jumper wires to connect the remaining pins of the 74HC595 to the ground rails of breadboard.
 
 ===== Circuit Diagram
 
@@ -69,18 +86,26 @@ Example possible values include:
 ===== Testing
 
 Use the below commands to test the component.
-This will cause the display to turn on and display the value `1234`.
+The first two commands will cause the display to turn on and display the value `1234`.
+
+The third command will cause the display to then show `1.234`.
+
+The fourth command will cause the display to show `1 34`, using standard URL encoding for the space (`%20`).
 
 [source,bash]
 ----
 $ curl http://localhost:8080/four-digit-seven-segment/enable
 $ curl http://localhost:8080/four-digit-seven-segment/displayValue/1234
+$ curl http://localhost:8080/four-digit-seven-segment/set-decimal-point/0/true
+$ curl http://localhost:8080/four-digit-seven-segment/displayValue/1%2034
 ----
 
 * `/enable` - Enables the display.
 * `/disable` - Disables the display.
-* `/displayValue/{value}` - Displays a custom value on the display.
+* `/print/{value}` - Displays a custom value on the display.
 * `/clear` - Clears the display.
+* `/set-digit/{digit}/{value}` - Sets a specific digit to a specific value.
+* `/set-decimal-point/{digit}/{value}` - Sets a specific decimal point to on (true) or off (false).
 
 ===== Troubleshooting
 

--- a/pi4micronaut-utils/src/main/java/com/opensourcewithslu/outputdevices/FourDigitSevenSegmentDisplayHelper.java
+++ b/pi4micronaut-utils/src/main/java/com/opensourcewithslu/outputdevices/FourDigitSevenSegmentDisplayHelper.java
@@ -100,8 +100,8 @@ public class FourDigitSevenSegmentDisplayHelper {
     /**
      * Helper method to shift out a byte to the shift register.
      *
-     * @param data
-     * @param decimalPointEnabled
+     * @param data Data to shift out
+     * @param decimalPointEnabled Whether the decimal point should be enabled or not
      */
     private void shiftOut(Integer data, boolean decimalPointEnabled) {
         int value;
@@ -126,9 +126,9 @@ public class FourDigitSevenSegmentDisplayHelper {
     /**
      * Helper method to shift out a value to a specific digit.
      *
-     * @param digit
-     * @param c
-     * @param decimalPoint
+     * @param digit The digit to shift the value to
+     * @param c The character to shift out
+     * @param decimalPoint Whether the decimal point should be enabled or not
      */
     private void shiftValueToDigit(int digit, char c, boolean decimalPoint) {
         digit0.low();
@@ -235,6 +235,7 @@ public class FourDigitSevenSegmentDisplayHelper {
     {
         displayValue = "";
         this.parseDisplayValue();
+        log.info("Display cleared");
     }
 
     /**
@@ -246,6 +247,7 @@ public class FourDigitSevenSegmentDisplayHelper {
     {
         this.enabled = true;
         this.startDisplayThread();
+        log.info("Display enabled");
     }
 
     /**
@@ -257,6 +259,7 @@ public class FourDigitSevenSegmentDisplayHelper {
     {
         this.clear();
         this.enabled = false;
+        log.info("Display disabled");
     }
 
     /**
@@ -269,6 +272,11 @@ public class FourDigitSevenSegmentDisplayHelper {
     public void print(String value)
     //end::method[]
     {
+        if (!enabled) {
+            log.error("Display must be enabled first");
+            return;
+        }
+
         // Check: Non-decimal point characters must be digits 0 to 1, letters A to F (case-insensitive), -, or space
         String noDecimals = value.replaceAll("\\.", "");
         String valid = "1234567890ABCDEFabcdef- ";
@@ -330,6 +338,7 @@ public class FourDigitSevenSegmentDisplayHelper {
         }
         digitValues[digit] = value;
         this.setDisplayValueFromDigitValues();
+        log.info("Digit {} set to {}", digit, value);
     }
 
     /**
@@ -347,5 +356,6 @@ public class FourDigitSevenSegmentDisplayHelper {
         }
         decimalPoints[digit] = enabled;
         this.setDisplayValueFromDigitValues();
+        log.info("Decimal point on digit {} set to {}", digit, enabled);
     }
 }

--- a/pi4micronaut-utils/src/test/java/com/opensourcewithslu/outputdevices/FourDigitSevenSegmentDisplayHelperTest.java
+++ b/pi4micronaut-utils/src/test/java/com/opensourcewithslu/outputdevices/FourDigitSevenSegmentDisplayHelperTest.java
@@ -26,7 +26,29 @@ public class FourDigitSevenSegmentDisplayHelperTest {
     }
 
     @Test
+    void enable() {
+        displayHelper.enable();
+        verify(log).info("Display enabled");
+    }
+
+    @Test
+    void disable() {
+        displayHelper.enable();
+        verify(log).info("Display enabled");
+        displayHelper.disable();
+        verify(log).info("Display disabled");
+    }
+
+    @Test
+    void printFailsWhenDisabled() {
+        displayHelper.print("1234");
+        verify(log).error("Display must be enabled first");
+        verify(log, never()).info("Displaying value: {}", "1234");
+    }
+
+    @Test
     void longNumberIsCutOff() {
+        displayHelper.enable();
         String value = "12345";
         displayHelper.print(value);
         verify(log).info("Displaying value: {}", "1234");
@@ -34,6 +56,7 @@ public class FourDigitSevenSegmentDisplayHelperTest {
 
     @Test
     void consecutiveDecimalPointIsParsed() {
+        displayHelper.enable();
         String value = "1..23";
         displayHelper.print(value);
         String myValue = " ";
@@ -46,6 +69,7 @@ public class FourDigitSevenSegmentDisplayHelperTest {
 
     @Test
     void multipleConsecutiveDecimalPointIsParsed() {
+        displayHelper.enable();
         String value = "1...3";
         displayHelper.print(value);
         verify(log).info("Displaying value: {}", "1. . .3");
@@ -55,6 +79,7 @@ public class FourDigitSevenSegmentDisplayHelperTest {
 
     @Test
     void decimalPointOnLeftEndCutsOff() {
+        displayHelper.enable();
         String value = ".1234";
         displayHelper.print(value);
         verify(log).info("Displaying value: {}", " .123");
@@ -64,6 +89,7 @@ public class FourDigitSevenSegmentDisplayHelperTest {
 
     @Test
     void invalidCharacterFails() {
+        displayHelper.enable();
         String value = "G";
         displayHelper.print(value);
         verify(log).error("Each display value digit must be numeric, a letter A to F (case insensitive), a hyphen, or a space");
@@ -72,6 +98,7 @@ public class FourDigitSevenSegmentDisplayHelperTest {
 
     @Test
     void displaysLetters() {
+        displayHelper.enable();
         String value = "ABCD";
         displayHelper.print(value);
         verify(log).info("Displaying value: {}", "ABCD");
@@ -82,6 +109,7 @@ public class FourDigitSevenSegmentDisplayHelperTest {
 
     @Test
     void displaysLettersWithLowercase() {
+        displayHelper.enable();
         String value = "abcd";
         displayHelper.print(value);
         verify(log).info("Displaying value: {}", "ABCD");
@@ -92,6 +120,7 @@ public class FourDigitSevenSegmentDisplayHelperTest {
 
     @Test
     void displaysLettersWithMixedCase() {
+        displayHelper.enable();
         String value = "aBcD";
         displayHelper.print(value);
         verify(log).info("Displaying value: {}", "ABCD");
@@ -102,6 +131,7 @@ public class FourDigitSevenSegmentDisplayHelperTest {
 
     @Test
     void displaysHyphen() {
+        displayHelper.enable();
         String value = "-";
         displayHelper.print(value);
         verify(log).info("Displaying value: {}", "-   ");
@@ -112,6 +142,7 @@ public class FourDigitSevenSegmentDisplayHelperTest {
 
     @Test
     void displaysSpaces() {
+        displayHelper.enable();
         String value = "2 2";
         displayHelper.print(value);
         verify(log).info("Displaying value: {}", "2 2 ");
@@ -122,6 +153,7 @@ public class FourDigitSevenSegmentDisplayHelperTest {
 
     @Test
     void displaysNegativeNumber() {
+        displayHelper.enable();
         String number = "-123";
         displayHelper.print(number);
         verify(log).info("Displaying value: {}", "-123");
@@ -132,6 +164,7 @@ public class FourDigitSevenSegmentDisplayHelperTest {
 
     @Test
     void displaysFourDigitNumber() {
+        displayHelper.enable();
         String number = "1234";
         displayHelper.print(number);
         verify(log).info("Displaying value: {}", "1234");
@@ -142,6 +175,7 @@ public class FourDigitSevenSegmentDisplayHelperTest {
 
     @Test
     void displaysThreeDigitNumber() {
+        displayHelper.enable();
         String number = "123";
         displayHelper.print(number);
         verify(log).info("Displaying value: {}", "123 ");
@@ -152,6 +186,7 @@ public class FourDigitSevenSegmentDisplayHelperTest {
 
     @Test
     void displaysTwoDigitNumber() {
+        displayHelper.enable();
         String number = "34";
         displayHelper.print(number);
         verify(log).info("Displaying value: {}", "34  ");
@@ -162,6 +197,7 @@ public class FourDigitSevenSegmentDisplayHelperTest {
 
     @Test
     void displaysOneDigitNumber() {
+        displayHelper.enable();
         String number = "4";
         displayHelper.print(number);
         verify(log).info("Displaying value: {}", "4   ");
@@ -172,6 +208,7 @@ public class FourDigitSevenSegmentDisplayHelperTest {
 
     @Test
     void displaysBlankValue() {
+        displayHelper.enable();
         String number = "";
         displayHelper.print(number);
         verify(log).info("Displaying value: {}", "    ");
@@ -182,6 +219,7 @@ public class FourDigitSevenSegmentDisplayHelperTest {
 
     @Test
     void displaysDecimalNumber() {
+        displayHelper.enable();
         String number = "1.23";
         displayHelper.print(number);
         verify(log).info("Displaying value: {}", "1.23 ");
@@ -192,6 +230,7 @@ public class FourDigitSevenSegmentDisplayHelperTest {
 
     @Test
     void displaysDecimalNumberWithLeadingDecimal() {
+        displayHelper.enable();
         String number = ".23";
         displayHelper.print(number);
         verify(log).info("Displaying value: {}", " .23 ");
@@ -202,6 +241,7 @@ public class FourDigitSevenSegmentDisplayHelperTest {
 
     @Test
     void displaysDecimalNumberWithTrailingDecimal() {
+        displayHelper.enable();
         String number = "1.";
         displayHelper.print(number);
         verify(log).info("Displaying value: {}", "1.   ");
@@ -212,6 +252,7 @@ public class FourDigitSevenSegmentDisplayHelperTest {
 
     @Test
     void displaysMultipleDecimals() {
+        displayHelper.enable();
         String number = "1.2.3.4.";
         displayHelper.print(number);
         verify(log).info("Displaying value: {}", "1.2.3.4.");
@@ -222,6 +263,7 @@ public class FourDigitSevenSegmentDisplayHelperTest {
 
     @Test
     void displaysSpacesAndDecimals() {
+        displayHelper.enable();
         String number = " . . . ";
         displayHelper.print(number);
         verify(log).info("Displaying value: {}", " . . . ");
@@ -232,14 +274,33 @@ public class FourDigitSevenSegmentDisplayHelperTest {
 
     @Test
     void clearDisplay() {
+        displayHelper.enable();
         String number = "1234";
         displayHelper.print(number);
 
         displayHelper.clear();
+        verify(log).info("Display cleared");
 
         String displayed = displayHelper.getDisplayValue();
         assertEquals("    ", displayed);
     }
 
-    /* TODO: Add tests for setDigit and setDecimalPoint */
+    @Test
+    void setsDigit() {
+        displayHelper.enable();
+        displayHelper.setDigit(0, 'A');
+        verify(log).info("Digit {} set to {}", 0, 'A');
+        String displayValue = displayHelper.getDisplayValue();
+        assertEquals("A   ", displayValue);
+    }
+
+    @Test
+    void setsDecimalPoint() {
+        displayHelper.enable();
+        displayHelper.print("1234");
+        displayHelper.setDecimalPoint(0, true);
+        verify(log).info("Decimal point on digit {} set to {}", 0, true);
+        String displayValue = displayHelper.getDisplayValue();
+        assertEquals("1.234", displayValue);
+    }
 }


### PR DESCRIPTION
Resolves #44. Added controller and helper for a 4-digit 7-segment display.

The pin configuration uses seven digital output pins, one for each digit and three for the mechanics of setting the display. The controller has methods for enabling/disabling, printing a value, setting the value of a specific digit, enabling/disabling specific decimal points on the display, and clearing the display.

The helper class can parse values passed into the print function into appropriate characters to display on each of the digits on the display. It also validates specific characters to display.

There is a test class for all public helper methods. All tests pass.

Documentation is also included in an AsciiDoc file describing the component, assembly, troubleshooting, and examples.