### PR TITLE
Added servo motor helper tests

### DIFF
--- a/pi4micronaut-utils/src/main/java/com/opensourcewithslu/outputdevices/ServoMotorHelper.java
+++ b/pi4micronaut-utils/src/main/java/com/opensourcewithslu/outputdevices/ServoMotorHelper.java
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ServoMotorHelper {
 
-    private static final Logger log = LoggerFactory.getLogger(ServoMotorHelper.class);
+    private static Logger log = LoggerFactory.getLogger(ServoMotorHelper.class);
     private static final int FREQUENCY = 50; // Frequency for PWM signal in Hz, typical for servo motors.
     private static final int PWM_CYCLE_MICROSECONDS = 20000; // Total cycle length in microseconds, corresponding to 50 Hz.
     private static final int MIN_ANGLE = 0; // Minimum angle for servo operation.
@@ -54,7 +54,7 @@ public class ServoMotorHelper {
      * @param value the angle in degrees to be mapped to pulse width.
      * @return the calculated pulse width in microseconds.
      */
-    private float map(float value) {
+    float map(float value) {
         return SERVO_MIN_PULSE + ((value - MIN_ANGLE) * (SERVO_MAX_PULSE - SERVO_MIN_PULSE) / (MAX_ANGLE - MIN_ANGLE));
     }
 
@@ -87,5 +87,23 @@ public class ServoMotorHelper {
             Thread.currentThread().interrupt(); // Properly handle thread interruption.
             log.info("Thread was interrupted, failed to complete rotation");
         }
+    }
+
+    /**
+     * Sets the logger for this ServoMotorHelper instance.
+     *
+     * @param logger the logger to be used for logging messages.
+     */
+    public void setLog(Logger logger) {
+        log = logger;
+    }
+
+    /**
+     * Returns the current state of the servo motor.
+     *
+     * @return true if the servo motor is enabled, false otherwise.
+     */
+    public boolean isEnabled() {
+        return isEnabled;
     }
 }

--- a/pi4micronaut-utils/src/test/java/com/opensourcewithslu/outputdevices/ServoMotorHelperTest.java
+++ b/pi4micronaut-utils/src/test/java/com/opensourcewithslu/outputdevices/ServoMotorHelperTest.java
@@ -1,0 +1,115 @@
+package com.opensourcewithslu.outputdevices;
+
+import com.pi4j.io.pwm.Pwm;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class ServoMotorHelperTest {
+    Logger log = mock(Logger.class);
+    Pwm servoMotor = mock(Pwm.class);
+    ServoMotorHelper servoMotorHelper = new ServoMotorHelper(servoMotor);
+
+    private static final int FREQUENCY = 50; // Frequency for PWM signal in Hz, typical for servo motors.
+    private static final int PWM_CYCLE_MICROSECONDS = 20000; // Total cycle length in microseconds, corresponding to 50 Hz.
+
+    @BeforeEach
+    public void openMocks() {
+        servoMotorHelper.setLog(log);
+    }
+
+    @Test
+    void enables() {
+        servoMotorHelper.enable();
+        verify(servoMotor).on(0, 50);
+        verify(log).info("Enabling servo motor");
+        assertTrue(servoMotorHelper.isEnabled());
+    }
+
+    @Test
+    void disables() {
+        servoMotorHelper.disable();
+        verify(servoMotor).off();
+        verify(log).info("Disabling servo motor");
+        assertFalse(servoMotorHelper.isEnabled());
+    }
+
+    @Test
+    void setAngleFailsWhenDisabled() {
+        servoMotorHelper.setAngle(90);
+        verify(log).info("You must enable the servo motor first.");
+        verify(servoMotor, never()).on(0, 50);
+        verify(log, never()).info("Setting angle to {} degrees", 90);
+    }
+
+    @Test
+    void setAngleLowFails() {
+        servoMotorHelper.enable();
+        servoMotorHelper.setAngle(-10);
+        verify(log).info("You must enter an angle between 0 and 180 degrees.");
+
+        float pulseWidth = servoMotorHelper.map(-10);
+        float dutyCycle = (pulseWidth / PWM_CYCLE_MICROSECONDS) * 100;
+
+        verify(servoMotor, never()).on(dutyCycle, FREQUENCY);
+        verify(log, never()).info("Setting angle to {} degrees", -10);
+    }
+
+    @Test
+    void setAngleHighFails() {
+        servoMotorHelper.enable();
+        servoMotorHelper.setAngle(181);
+        verify(log).info("You must enter an angle between 0 and 180 degrees.");
+
+        float pulseWidth = servoMotorHelper.map(181);
+        float dutyCycle = (pulseWidth / PWM_CYCLE_MICROSECONDS) * 100;
+
+        verify(servoMotor, never()).on(dutyCycle, FREQUENCY);
+        verify(log, never()).info("Setting angle to {} degrees", 181);
+    }
+
+    @Test
+    void setAngleAtMinimumValue() {
+        servoMotorHelper.enable();
+        servoMotorHelper.setAngle(0);
+
+        float pulseWidth = servoMotorHelper.map(0);
+        float dutyCycle = (pulseWidth / PWM_CYCLE_MICROSECONDS) * 100;
+
+        verify(log).info("Setting servo to {} degrees, Pulse Width: {} us, Duty Cycle: {}%", 0, pulseWidth, dutyCycle);
+        verify(servoMotor).on(dutyCycle, FREQUENCY);
+    }
+
+    @Test
+    void setAngleAtMaximumValue() {
+        servoMotorHelper.enable();
+
+        float pulseWidth = servoMotorHelper.map(180);
+        float dutyCycle = (pulseWidth / PWM_CYCLE_MICROSECONDS) * 100;
+
+        servoMotorHelper.setAngle(180);
+        verify(log).info("Setting servo to {} degrees, Pulse Width: {} us, Duty Cycle: {}%", 180, pulseWidth, dutyCycle);
+        verify(servoMotor).on(dutyCycle, FREQUENCY);
+    }
+
+    @Test
+    void setAngle() {
+        servoMotorHelper.enable();
+
+        float pulseWidth = servoMotorHelper.map(90);
+        float dutyCycle = (pulseWidth / PWM_CYCLE_MICROSECONDS) * 100;
+
+        servoMotorHelper.setAngle(90);
+        verify(log).info("Setting servo to {} degrees, Pulse Width: {} us, Duty Cycle: {}%", 90, pulseWidth, dutyCycle);
+        verify(servoMotor).on(dutyCycle, FREQUENCY);
+    }
+
+    @Test
+    void map() {
+        assertEquals(500, servoMotorHelper.map(0));
+        assertEquals(2500, servoMotorHelper.map(180));
+        assertEquals(1500, servoMotorHelper.map(90));
+    }
+}

--- a/pi4micronaut-utils/src/test/java/com/opensourcewithslu/outputdevices/ServoMotorHelperTest.java
+++ b/pi4micronaut-utils/src/test/java/com/opensourcewithslu/outputdevices/ServoMotorHelperTest.java
@@ -1,5 +1,6 @@
 package com.opensourcewithslu.outputdevices;
 
+import com.pi4j.io.exception.IOException;
 import com.pi4j.io.pwm.Pwm;
 import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
@@ -22,16 +23,24 @@ public class ServoMotorHelperTest {
 
     @Test
     void enables() {
-        servoMotorHelper.enable();
-        verify(servoMotor).on(0, 50);
+        try {
+            servoMotorHelper.enable();
+            verify(servoMotor).on(0, 50);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         verify(log).info("Enabling servo motor");
         assertTrue(servoMotorHelper.isEnabled());
     }
 
     @Test
     void disables() {
-        servoMotorHelper.enable();
-        servoMotorHelper.disable();
+        try {
+            servoMotorHelper.enable();
+            servoMotorHelper.disable();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
         verify(servoMotor).off();
         verify(log).info("Disabling servo motor");
         assertFalse(servoMotorHelper.isEnabled());
@@ -39,7 +48,11 @@ public class ServoMotorHelperTest {
 
     @Test
     void setAngleFailsWhenDisabled() {
-        servoMotorHelper.setAngle(90);
+        try {
+            servoMotorHelper.setAngle(90);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
         verify(log).info("You must enable the servo motor first.");
         verify(servoMotor, never()).on(0, 50);
         verify(log, never()).info("Setting angle to {} degrees", 90);
@@ -47,8 +60,12 @@ public class ServoMotorHelperTest {
 
     @Test
     void setAngleLowFails() {
-        servoMotorHelper.enable();
-        servoMotorHelper.setAngle(-10);
+        try {
+            servoMotorHelper.enable();
+            servoMotorHelper.setAngle(-10);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
         verify(log).info("You must enter an angle between 0 and 180 degrees.");
 
         float pulseWidth = servoMotorHelper.map(-10);
@@ -60,8 +77,12 @@ public class ServoMotorHelperTest {
 
     @Test
     void setAngleHighFails() {
-        servoMotorHelper.enable();
-        servoMotorHelper.setAngle(181);
+        try {
+            servoMotorHelper.enable();
+            servoMotorHelper.setAngle(181);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
         verify(log).info("You must enter an angle between 0 and 180 degrees.");
 
         float pulseWidth = servoMotorHelper.map(181);
@@ -73,8 +94,12 @@ public class ServoMotorHelperTest {
 
     @Test
     void setAngleAtMinimumValue() {
-        servoMotorHelper.enable();
-        servoMotorHelper.setAngle(0);
+        try {
+            servoMotorHelper.enable();
+            servoMotorHelper.setAngle(0);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
 
         float pulseWidth = servoMotorHelper.map(0);
         float dutyCycle = (pulseWidth / PWM_CYCLE_MICROSECONDS) * 100;
@@ -85,24 +110,40 @@ public class ServoMotorHelperTest {
 
     @Test
     void setAngleAtMaximumValue() {
-        servoMotorHelper.enable();
+        try {
+            servoMotorHelper.enable();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
 
         float pulseWidth = servoMotorHelper.map(180);
         float dutyCycle = (pulseWidth / PWM_CYCLE_MICROSECONDS) * 100;
 
-        servoMotorHelper.setAngle(180);
+        try {
+            servoMotorHelper.setAngle(180);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
         verify(log).info("Setting servo to {} degrees, Pulse Width: {} us, Duty Cycle: {}%", 180, pulseWidth, dutyCycle);
         verify(servoMotor).on(dutyCycle, FREQUENCY);
     }
 
     @Test
     void setAngle() {
-        servoMotorHelper.enable();
+        try {
+            servoMotorHelper.enable();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
 
         float pulseWidth = servoMotorHelper.map(90);
         float dutyCycle = (pulseWidth / PWM_CYCLE_MICROSECONDS) * 100;
 
-        servoMotorHelper.setAngle(90);
+        try {
+            servoMotorHelper.setAngle(90);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
         verify(log).info("Setting servo to {} degrees, Pulse Width: {} us, Duty Cycle: {}%", 90, pulseWidth, dutyCycle);
         verify(servoMotor).on(dutyCycle, FREQUENCY);
     }

--- a/pi4micronaut-utils/src/test/java/com/opensourcewithslu/outputdevices/ServoMotorHelperTest.java
+++ b/pi4micronaut-utils/src/test/java/com/opensourcewithslu/outputdevices/ServoMotorHelperTest.java
@@ -27,7 +27,7 @@ public class ServoMotorHelperTest {
             servoMotorHelper.enable();
             verify(servoMotor).on(0, 50);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Error running test: ", e);
         }
         verify(log).info("Enabling servo motor");
         assertTrue(servoMotorHelper.isEnabled());
@@ -39,7 +39,7 @@ public class ServoMotorHelperTest {
             servoMotorHelper.enable();
             servoMotorHelper.disable();
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Error running test: ", e);
         }
         verify(servoMotor).off();
         verify(log).info("Disabling servo motor");
@@ -51,7 +51,7 @@ public class ServoMotorHelperTest {
         try {
             servoMotorHelper.setAngle(90);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Error running test: ", e);
         }
         verify(log).info("You must enable the servo motor first.");
         verify(servoMotor, never()).on(0, 50);
@@ -64,7 +64,7 @@ public class ServoMotorHelperTest {
             servoMotorHelper.enable();
             servoMotorHelper.setAngle(-10);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Error running test: ", e);
         }
         verify(log).info("You must enter an angle between 0 and 180 degrees.");
 
@@ -81,7 +81,7 @@ public class ServoMotorHelperTest {
             servoMotorHelper.enable();
             servoMotorHelper.setAngle(181);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Error running test: ", e);
         }
         verify(log).info("You must enter an angle between 0 and 180 degrees.");
 
@@ -98,7 +98,7 @@ public class ServoMotorHelperTest {
             servoMotorHelper.enable();
             servoMotorHelper.setAngle(0);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Error running test: ", e);
         }
 
         float pulseWidth = servoMotorHelper.map(0);
@@ -113,7 +113,7 @@ public class ServoMotorHelperTest {
         try {
             servoMotorHelper.enable();
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Error running test: ", e);
         }
 
         float pulseWidth = servoMotorHelper.map(180);
@@ -122,7 +122,7 @@ public class ServoMotorHelperTest {
         try {
             servoMotorHelper.setAngle(180);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Error running test: ", e);
         }
         verify(log).info("Setting servo to {} degrees, Pulse Width: {} us, Duty Cycle: {}%", 180, pulseWidth, dutyCycle);
         verify(servoMotor).on(dutyCycle, FREQUENCY);
@@ -133,7 +133,7 @@ public class ServoMotorHelperTest {
         try {
             servoMotorHelper.enable();
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Error running test: ", e);
         }
 
         float pulseWidth = servoMotorHelper.map(90);
@@ -142,7 +142,7 @@ public class ServoMotorHelperTest {
         try {
             servoMotorHelper.setAngle(90);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Error running test: ", e);
         }
         verify(log).info("Setting servo to {} degrees, Pulse Width: {} us, Duty Cycle: {}%", 90, pulseWidth, dutyCycle);
         verify(servoMotor).on(dutyCycle, FREQUENCY);

--- a/pi4micronaut-utils/src/test/java/com/opensourcewithslu/outputdevices/ServoMotorHelperTest.java
+++ b/pi4micronaut-utils/src/test/java/com/opensourcewithslu/outputdevices/ServoMotorHelperTest.java
@@ -30,6 +30,7 @@ public class ServoMotorHelperTest {
 
     @Test
     void disables() {
+        servoMotorHelper.enable();
         servoMotorHelper.disable();
         verify(servoMotor).off();
         verify(log).info("Disabling servo motor");


### PR DESCRIPTION
Added tests for the servo motor's helper class. Run the tests with `gradle test` or `./gradlew test`. 

The tests check the following:

* The `map` function appropriately computes the pulse width from the desired angle for the motor
* The `enable` and `disable` functions work
* The motor angle cannot be set before the motor is enabled
* The motor angle must be within a range 0-180 degrees
* Setting the motor angle works within that range