### PR TITLE
Added Documentation for index.adoc

### DIFF
--- a/pi4micronaut-utils/src/docs/asciidoc/index.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/index.adoc
@@ -41,14 +41,14 @@ include::components/commun_WithHardware/digitalInput.adoc[]
 
 include::components/commun_WithHardware/digitalOutput.adoc[]
 
+include::components/commun_WithHardware/i2c.adoc[]
+
 include::components/commun_WithHardware/multipinConfig.adoc[]
 
 include::components/commun_WithHardware/pwm.adoc[]
 
 include::components/commun_WithHardware/spi.adoc[]
 
-
-include::components/commun_WithHardware/i2c.adoc[]
 
 include::components/inputComponents.adoc[]
 
@@ -74,6 +74,11 @@ include::components/inputComponents/microSwitch.adoc[]
 
 include::components/inputComponents/thermistor.adoc[]
 
+include::components/inputComponents/photosensor.adoc[]
+
+include::components/inputComponents/speedSensor.adoc[]
+
+
 include::components/outputComponents.adoc[]
 
 include::components/outputComponents/led.adoc[]
@@ -88,6 +93,8 @@ include::components/outputComponents/activebuzzer.adoc[]
 
 include::components/outputComponents/servomotor.adoc[]
 
-include::components/inputComponents/photoresistorSensor.adoc[]
+include::components/outputComponents/fan.adoc[]
 
-include::components/inputComponents/pirSensor.adoc[]
+include::components/outputComponents/fourDigitSevenSegment.adoc[]
+
+include::components/outputComponents/motor.adoc[]

--- a/pi4micronaut-utils/src/docs/asciidoc/index.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/index.adoc
@@ -87,3 +87,7 @@ include::components/outputComponents/passivebuzzer.adoc[]
 include::components/outputComponents/activebuzzer.adoc[]
 
 include::components/outputComponents/servomotor.adoc[]
+
+include::components/inputComponents/photoresistorSensor.adoc[]
+
+include::components/inputComponents/pirSensor.adoc[]

--- a/pi4micronaut-utils/src/docs/asciidoc/introduction.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/introduction.adoc
@@ -1,19 +1,16 @@
 == Introduction
 
-[.text-right]
-https://github.com/oss-slu/Pi4Micronaut/edit/develop/pi4micronaut-utils/src/docs/asciidoc/introduction.adoc[Improve this doc]
+:improve-doc-url: https://github.com/oss-slu/Pi4Micronaut/edit/develop/pi4micronaut-utils/src/docs/asciidoc/introduction.adoc
 
+[align="right"]
+link:{improve-doc-url}[Improve this doc]
 
-
-
+//
 
 Welcome to the **Pi4Micronaut Documentation**!
 
-Pi4Micronaut is an Open Source Java library which utilizes the Micronaut Framework and Pi4J to streamline the process of creating custom IoT applications that require hardware connectivity to Raspberry Pi's.
+Pi4Micronaut is an Open Source Java library that utilizes the Micronaut Framework and Pi4J to streamline the process of creating custom IoT applications that require hardware connectivity to Raspberry Pi's.
 
-**Note:** Pi4Micronaut doesn't work with the latest Raspberry Pi 5 because of its whole new architecture. Pi4J and pigpio libraries doesn't provide support for Pi 5 yet. Look out for the latest version of Pi4J to work with Pi5's in the future.
+Pi4Micronaut doesn't work with the latest Raspberry Pi 5 because of its new architecture. Pi4J and pigpio libraries don't provide support for Pi 5 yet. Look out for the latest version of Pi4J that will work with Pi 5 in the future.
 
 By reading through our documentation, you will learn how to implement our library into your application.
-
-
-


### PR DESCRIPTION
Fixes #310 & #311

**What was changed?** 
Documentation and missing components were added to the index.adoc file. UI Bug in introduction.adoc fixed.

**Why was it changed?**
The documentation beforehand was missing several includes which prevented some of the components from appearing in the main documentation. The text in introduction.adoc should be aligned to the right accordingly.

**How was it changed?**
Observing the index.adoc file, missing components were identified by matching the contents to the files in inputsComponents folder. The index.adoc file was then updated to include the missing components. The input components photosensor and speedsensor were missing. The output components fan, fourDigitSevenSegment, and motor were missing. A delimited block was implemented to structure the URL to the right. A gradle test was run and the build was successful.

![gradlew asciidoctor](https://github.com/user-attachments/assets/70808eca-c9b0-4534-8e67-9e1be9a9d7bf)
![task](https://github.com/user-attachments/assets/0d5ab54f-9d96-4be7-b0c3-7738cb4a9047)
![buildsuccessful](https://github.com/user-attachments/assets/7b3efd79-4adc-4e5b-b97a-a8be5eb5f558)