### PR TITLE
Added the RGBLEDHelper and successful the hardware testing 

### DIFF
--- a/pi4micronaut-utils/src/main/java/com/opensourcewithslu/inputdevices/PushButtonHelper.java
+++ b/pi4micronaut-utils/src/main/java/com/opensourcewithslu/inputdevices/PushButtonHelper.java
@@ -1,0 +1,72 @@
+package com.opensourcewithslu.inputdevices;
+
+import com.pi4j.io.gpio.digital.DigitalInput;
+import com.pi4j.io.gpio.digital.DigitalStateChangeListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The PushButtonHelper class is used to create a listener that determines when a 4 pin button is pressed.
+ * verified for Micronaut 4.7.6, awaiting hardware testing
+ */
+public class PushButtonHelper {
+    private static final Logger log = LoggerFactory.getLogger(PushButtonHelper.class);
+
+
+    private final DigitalInput buttonInput;
+
+    /**
+     * Determines if the button is pressed.
+     */
+    public Boolean isPressed;
+
+    /**
+     * The PushButtonHelper constructor.
+     * @param buttonInput A Pi4J DigitalInput Object.
+     */
+    //tag::const[]
+    public PushButtonHelper(DigitalInput buttonInput)
+    //end::const[]
+    {
+        this.buttonInput = buttonInput;
+        this.isPressed = buttonInput.isHigh();
+
+        initialize();
+    }
+
+    /**
+     * Initializes the PushButton. Automatically called when the PushButton is created.
+     */
+    //tag::method[]
+    public void initialize()
+    //end::method[]
+    {
+        log.info("Initializing " + buttonInput.getName());
+
+        buttonInput.addListener(e->
+                isPressed = buttonInput.isHigh()
+        );
+    }
+
+    /**
+     * Adds an EventListener to the PushButton.
+     * @param function A DigitalStateChangeListener Object.
+     */
+    //tag::method[]
+    public void addEventListener(DigitalStateChangeListener function)
+    //end::method[]
+    {
+        buttonInput.addListener(function);
+    }
+
+    /**
+     * Removes an EvenListener from the button.
+     * @param function The listener to be removed.
+     */
+    //tag::method[]
+    public void removeEventListener(DigitalStateChangeListener function)
+    //end::method[]
+    {
+        buttonInput.removeListener(function);
+    }
+}

--- a/pi4micronaut-utils/src/main/java/com/opensourcewithslu/outputdevices/RGBLEDHelper.java
+++ b/pi4micronaut-utils/src/main/java/com/opensourcewithslu/outputdevices/RGBLEDHelper.java
@@ -1,0 +1,204 @@
+package com.opensourcewithslu.outputdevices;
+
+import com.opensourcewithslu.utilities.MultiPinConfiguration;
+import com.pi4j.io.pwm.Pwm;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The RBGLEDHelper class handles all interactions with a RGB LED.
+ */
+public class RGBLEDHelper {
+    private static final Logger log = LoggerFactory.getLogger(RGBLEDHelper.class);
+
+    private final Pwm red;
+
+    private final Pwm green;
+
+    private final Pwm blue;
+
+    /**
+     * The RGBLEDHelper constructor.
+     * @param pwm A {@link  com.opensourcewithslu.utilities.MultiPinConfiguration} Object.
+     */
+    //tag::const[]
+    public RGBLEDHelper(MultiPinConfiguration pwm)
+    //end::const[]
+    {
+        log.info("Init rgb");
+        Pwm[] pwms = (Pwm[]) pwm.getComponents();
+        this.red = pwms[0];
+        this.green = pwms[1];
+        this.blue = pwms[2];
+    }
+
+    /**
+     * Sets the color of the LED based of inputted RGB values. Set with a default frequency of 200 Hertz.
+     * @param colors RGB values in an array. [Red,Green,Blue].
+     */
+    //tag::method[]
+    public void setColor(int[] colors)
+    //end::method[]
+    {
+        red.on(colors[0], 200);
+        green.on(colors[1], 200);
+        blue.on(colors[2], 200);
+    }
+
+    /**
+     * Sets the color of the LED using the array of RGB values and an array of frequencies.
+     * @param colors RGB values in an array. [Red,Green,Blue].
+     * @param frequency Frequency values(in Hertz) for the corresponding RGB value. [Red frequency, Green frequency, Blue frequency]
+     */
+    //tag::method[]
+    public void setColor(int[] colors, int[] frequency)
+    //end::method[]
+    {
+        log.info("setting the colors and frequency via a list");
+        red.on(colors[0], frequency[0]);
+        green.on(colors[1], frequency[1]);
+        blue.on(colors[2], frequency[2]);
+    }
+
+    /**
+     * Setting the color of the LED using a hexadecimal value. Default frequency of 200 Hertz is used.
+     * @param hex Hexadecimal number optionally prefixed by 0x.
+     */
+    //tag::method[]
+    public void setColorHex(String hex)
+    //end::method[]
+    {
+        log.info("setting the color via hex");
+        // hex splitting into rbg int values
+        int r = (Integer.decode(hex) & 0xFF0000) >> 16;
+        int g = (Integer.decode(hex) & 0xFF00) >> 8;
+        int b = (Integer.decode(hex) & 0xFF);
+
+        // no frequency input, default value 200
+        red.on(r, 200);
+        green.on(g, 200);
+        blue.on(b, 200);
+    }
+
+
+    /**
+     *  Setting the color of the LED using a hexadecimal value and an array of frequencies.
+     * @param hex Hexadecimal number optionally prefixed by 0x.
+     * @param frequency Frequency values(in Hertz) for the corresponding RGB value. [Red frequency, Green frequency, Blue frequency]
+     */
+    //tag::method[]
+    public void setColorHex(String hex, int[] frequency)
+    //end::method[]
+    {
+        log.info("Setting the color via Hex and a list of frequencies(RGB)");
+        // hex splitting into rbg int values
+        int r = (Integer.decode(hex) & 0xFF0000) >> 16;
+        int g = (Integer.decode(hex) & 0xFF00) >> 8;
+        int b = (Integer.decode(hex) & 0xFF);
+
+        red.on(r, frequency[0]);
+        green.on(g, frequency[1]);
+        blue.on(b, frequency[2]);
+    }
+
+    /**
+     * Sets the red value of the LED. Default 200 Hertz frequency used.
+     * @param red Integer value representing the red in the RGB value of the LED.
+     */
+    //tag::method[]
+    public void setRed(int red)
+    //end::method[]
+    {
+        log.info("Set red");
+        this.red.on(red, 200);
+    }
+
+    /**
+     * Sets the red value and frequency of the LED.
+     * @param red Integer value representing the red in the RGB value of the LED.
+     * @param frequency Frequency of the red value in Hertz.
+     */
+    //tag::method[]
+    public void setRed(int red, int frequency)
+    //end::method[]
+    {
+        log.info("set red and set frequency");
+        this.red.on(red, frequency);
+    }
+
+    /**
+     * Sets the blue value of the LED. Default 200 Hertz frequency used.
+     * @param blue Integer value representing the blue in the RGB value of the LED.
+     */
+    //tag::method[]
+    public void setBlue(int blue)
+    //end::method[]
+    {
+        log.info("set blue");
+        this.blue.on(blue, 200);
+    }
+
+    /**
+     * Sets the blue value and frequency of the LED.
+     * @param blue Integer value representing the blue in the RGB value of the LED.
+     * @param frequency Frequency of the blue value in Hertz.
+     */
+    //tag::method[]
+    public void setBlue(int blue, int frequency)
+    //end::method[]
+    {
+        log.info("set blue and set frequency");
+        this.blue.on(blue, frequency);
+    }
+
+    /**
+     * Sets the green value of the LED. Default 200 Hertz frequency used.
+     * @param green Integer value representing the green in the RGB value of the LED.
+     */
+    //tag::method[]
+    public void setGreen(int green)
+    //end::method[]
+    {
+        log.info("set green");
+        this.green.on(green, 200);
+    }
+
+    /**
+     *  Sets the green value and frequency of the LED.
+     * @param green Integer value representing the green in the RGB value of the LED.
+     * @param frequency Frequency of the green value in Hertz.
+     */
+    //tag::method[]
+    public void setGreen(int green, int frequency)
+    //end::method[]
+    {
+        log.info("Setting green color and its frequency");
+        this.green.on(green, frequency);
+    }
+
+    /**
+     * Turns off the RGB LED.
+     */
+    //tag::method[]
+    public void ledOff()
+    //end::method[]
+    {
+        log.info("Turning off RGB LED");
+        this.red.off();
+        this.green.off();
+        this.blue.off();
+    }
+
+    /**
+     * Turns on the RGB LED with default RGB values of 100,100,100 and frequencies of 200 Hertz.
+     */
+    //tag::method[]
+    public void ledOn()
+    //end::method[]
+    {
+        log.info("turning on each LED pin and setting to 100");
+        this.red.on(100, 200);
+        this.green.on(100, 200);
+        this.blue.on(100, 200);
+    }
+}

--- a/pi4micronaut-utils/src/main/java/com/opensourcewithslu/utilities/DigitalInputConfiguration.java
+++ b/pi4micronaut-utils/src/main/java/com/opensourcewithslu/utilities/DigitalInputConfiguration.java
@@ -23,7 +23,7 @@ public class DigitalInputConfiguration {
      * Constructor for the DigitalInputConfiguration.
      * @param id The configuration id as defined in the application.yml
      */
-    public DigitalInputConfiguration(@Parameter String id) {
+    public DigitalInputConfiguration(String id) {
         this.id = id;
     }
 

--- a/pi4micronaut-utils/src/main/java/com/opensourcewithslu/utilities/DigitalOutputConfiguration.java
+++ b/pi4micronaut-utils/src/main/java/com/opensourcewithslu/utilities/DigitalOutputConfiguration.java
@@ -1,14 +1,13 @@
 package com.opensourcewithslu.utilities;
 
 import com.pi4j.io.gpio.digital.DigitalState;
+import io.micronaut.context.annotation.ConfigurationInject;
 import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Parameter;
-import io.micronaut.context.annotation.Prototype;
 
 /**
  * This class handles the configuration of a digital output component.
  */
-@Prototype
 @EachProperty("pi4j.digital-output")
 public class DigitalOutputConfiguration {
 
@@ -23,6 +22,7 @@ public class DigitalOutputConfiguration {
      * The DigitalOutputConfiguration constructor.
      * @param id The configuration id as defined in the application.yml.
      */
+    @ConfigurationInject
     public DigitalOutputConfiguration(@Parameter String id) {
         this.id = id;
     }

--- a/pi4micronaut-utils/src/test/java/com/opensourcewithslu/Pi4MicronautUtilsTest.java
+++ b/pi4micronaut-utils/src/test/java/com/opensourcewithslu/Pi4MicronautUtilsTest.java
@@ -1,0 +1,46 @@
+package com.opensourcewithslu;
+
+import com.opensourcewithslu.utilities.DigitalOutputConfiguration;
+import com.pi4j.io.gpio.digital.DigitalState;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.PropertySource;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test class to verify the configuration binding of DigitalOutputConfiguration.
+ */
+public class Pi4MicronautUtilsTest {
+
+    @Test
+    public void testDigitalOutputConfigurationBindingForLed() {
+        // Create an in-memory property source that simulates the YAML configuration for the "led" digital output.
+        ApplicationContext ctx = ApplicationContext.run(
+                PropertySource.of("test",
+                        "pi4j.digital-output.led.name", "LED Output",
+                        "pi4j.digital-output.led.address", "17",
+                        "pi4j.digital-output.led.shutdown", "LOW",
+                        "pi4j.digital-output.led.initial", "LOW",
+                        "pi4j.digital-output.led.provider", "pigpio-digital-output"
+                )
+        );
+
+        // Retrieve the bean corresponding to the configuration entry with key "led"
+        DigitalOutputConfiguration config = ctx.getBean(
+                DigitalOutputConfiguration.class,
+                Qualifiers.byName("led")
+        );
+
+
+        // Verify that each property has been bound correctly.
+        Assertions.assertEquals("led", config.getId(), "Expected bean id to be 'led'");
+        Assertions.assertEquals("LED Output", config.getName(), "Expected name to be 'LED Output'");
+        Assertions.assertEquals(17, config.getAddress(), "Expected address to be 17");
+        Assertions.assertEquals(DigitalState.LOW, config.getShutdown(), "Expected shutdown state to be LOW");
+        Assertions.assertEquals(DigitalState.LOW, config.getInitial(), "Expected initial state to be LOW");
+        Assertions.assertEquals("pigpio-digital-output", config.getProvider(), "Expected provider to be 'pigpio-digital-output'");
+
+        ctx.close();
+    }
+}


### PR DESCRIPTION
Fixes #316 
What was changed: I added the RGBLEDHelper class upon upgrade-micronaut branch for hardware testing purpose. This class provides methods to control the RGB LED by allowing color changes via individual red, green, blud values or hexadecimal input, along with configurable PWM frequencies. 

Why was changed: The upgrade to the newer Micronaut version resulted in the absence of REBLEDHelper class, which was available in previous versions. Reintroduing this functionality is essential for maintaining hardware testing capabilities and ensuring consistent behavior across different software versions.

How it was changed:  I implemented the GRBLEDHelper class by leveraging the PWM interface to manage individual LED channels(red, green, and blue). The class includes methods that support setting colors using both integer arrays and hexadecimal values, with default frequencies (200 Hz) provided where no specific frequency is given. Additionally, I enhanced the code with logging statements to improve monitoring and troubleshooting during hardware operations. 

The evidence of successful hardware testing on RGBLEDHelper.
https://github.com/user-attachments/assets/1aa62bf7-2592-4262-80f8-f93d0c9e6f0f

