### PR TITLE
upgrading rfid class

### DIFF
--- a/components/src/main/java/com/opensourcewithslu/components/controllers/RfidController.java
+++ b/components/src/main/java/com/opensourcewithslu/components/controllers/RfidController.java
@@ -1,0 +1,31 @@
+package com.opensourcewithslu.components.controllers;
+
+import com.opensourcewithslu.inputdevices.RFidHelper;
+import com.pi4j.context.Context;
+import com.pi4j.io.spi.SpiConfig;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Post;
+import jakarta.inject.Named;
+
+//tag::ex[]
+@Controller("/rfid")
+public class RfidController {
+    private final RFidHelper rfidHelper;
+
+    public RfidController(@Named("rfid") SpiConfig spi, Context pi4jContext){
+        this.rfidHelper = new RFidHelper(spi, 25, pi4jContext);
+    }
+
+    @Post("/write/{value}")
+    public void writeToCard(String value){
+        rfidHelper.writeToCard(value);
+    }
+
+    @Get("/read")
+    public String readFromCard(){
+        Object data = rfidHelper.readFromCard();
+        return data.toString();
+    }
+}
+//end::ex[]

--- a/pi4micronaut-utils/src/main/java/com/opensourcewithslu/inputdevices/RFidHelper.java
+++ b/pi4micronaut-utils/src/main/java/com/opensourcewithslu/inputdevices/RFidHelper.java
@@ -1,0 +1,90 @@
+package com.opensourcewithslu.inputdevices;
+
+import com.pi4j.crowpi.components.exceptions.RfidException;
+import com.pi4j.context.Context;
+import com.pi4j.io.spi.SpiConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.pi4j.crowpi.components.RfidComponent;
+import java.util.concurrent.atomic.AtomicReference;
+
+
+/**
+ *  The RFIDHelper class is for interacting with an RFID scanner.
+ */
+public class RFidHelper {
+    private static final Logger log = LoggerFactory.getLogger(RFidHelper.class);
+
+    private final RfidComponent scanner;
+
+    /**
+     * The RFidHelper constructor WITH the reset pin as a parameter.
+     * @param config A Pi4J SPIConfig object which holds the SPI address and SPI Baud rate for RFID scanner.
+     * @param reset Defines the reset pin for the RFID scanner.
+     * @param pi4jContext The Pi4J context object.
+     */
+    //tag::const[]
+    public RFidHelper(SpiConfig config, int reset, Context pi4jContext)
+    //end::const[]
+    {
+        this.scanner = new RfidComponent(pi4jContext, reset, config.getAddress(), config.getBaud());
+    }
+
+    /**
+     * The RFidHelper constructor WITHOUT the reset pin as a parameter.
+     * @param config A Pi4J SPIConfig object which holds the SPI address and SPI Baud rate for RFID scanner.
+     * @param pi4jContext The Pi4J context object.
+     */
+    //tag::const[]
+    public RFidHelper(SpiConfig config, Context pi4jContext)
+    //end::const[]
+    {
+        this.scanner = new RfidComponent(pi4jContext, config.getAddress(), config.getBaud());
+    }
+
+    /**
+     * Writes data to an RFID fob. This is the data that is returned when the fob is scanned by the scanner.
+     * @param data Data to be written to an RFID fob. Typically, a string identifying the holder of the fob such as an identification number.
+     */
+    //tag::method[]
+    public void writeToCard(Object data)
+    //end::method[]
+    {
+        scanner.waitForAnyCard(card -> {
+            try {
+                card.writeObject(data);
+            } catch (RfidException e){
+                log.info(e.getMessage());
+            }
+        });
+    }
+
+    /**
+     *  When called, this method waits for any RFID card/fob to be scanned. The data from the card is returned.
+     * @return The data read from the card/fob.
+     */
+    //tag::method[]
+    public Object readFromCard()
+    //end::method[]
+    {
+        AtomicReference<Object> data = new AtomicReference<>(new Object());
+        scanner.waitForAnyCard(card -> {
+            try {
+                data.set(card.readObject());
+            } catch (RfidException e){
+                log.info(e.getMessage());
+            }
+        });
+        return data;
+    }
+
+    /**
+     * Resets the RFID scanner.
+     */
+    //tag::method[]
+    public void resetScanner()
+    //end::method[]
+    {
+        scanner.reset();
+    }
+}


### PR DESCRIPTION
#338 

What what changed:
I verified that the RFidHelper and RFidController classes remain compatible with Micronaut 4.7.6. At the point there are no required code changed, as the classes do not directly depend on the Micronaut features that needed to be changed. Hardware testing is still in the works, and further changed may be needed based on those results.

Why it was changed:
Part of the Micronaut 4.7.6 upgraded all of these classes needed to be looked over to ensure compatibility. We needed to review the code to ensure that future updates do not bring undefined behavior.

How it was changed:
Reviewed RFidHelper and RFidController for breaking changed in Micronaut 4.7.6, confirmed that all of the methods continue to be valid after the update. Ran with gradle and separate testing to ensure no compilation errors. Did not make any code changes for the time being, but hardware testing is still required.