### PR TITLE
Remove photosensor.adoc file and its references

### DIFF
--- a/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/photosensor.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/photosensor.adoc
@@ -1,5 +1,0 @@
-==== Photosensor
-[.text-right] 
-https://github.com/oss-slu/Pi4Micronaut/edit/develop/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/photosensor.adoc[Improve this doc]
-
-TODO: add in photosensor support docs

--- a/pi4micronaut-utils/src/docs/asciidoc/index.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/index.adoc
@@ -74,8 +74,6 @@ include::components/inputComponents/microSwitch.adoc[]
 
 include::components/inputComponents/thermistor.adoc[]
 
-include::components/inputComponents/photosensor.adoc[]
-
 include::components/inputComponents/speedSensor.adoc[]
 
 


### PR DESCRIPTION
Changes:
- `photosensor.adoc` file removed
- References to the `photosensor.adoc` file removed

Closes #367