### PR TITLE
Correct misspelling in image names

### DIFF
--- a/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/photoresistorSensor.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/photoresistorSensor.adoc
@@ -45,7 +45,7 @@ This section provides the details of the PhotoResistor Sensor including its comp
 
 ===== Circuit Diagram
 
-image::photoResistor-CD.png[]
+image::photoresistor-CD.png[]
 
 ===== Functionality
 PhotoResistor is a DigitalInput and DigitalOutput type that controls the LED's behavior based on changes in light intensity.

--- a/pi4micronaut-utils/src/docs/asciidoc/components/outputComponents/motor.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/outputComponents/motor.adoc
@@ -48,7 +48,7 @@ This section provides details of the DC motor, including its components and asse
 
 ===== Circuit Diagram
 
-image::motor_bb.png[]
+image::Motor_bb.png[]
 
 ===== Schematic Diagram
 


### PR DESCRIPTION
Changes:
- Corrected file names `photoresistor-CD.png` and `Motor_bb.png` in `photoresistorSensor.adoc` and `motor.adoc` to match the actual image file names

Closes #365 