### PR TITLE
Add root-level build.gradle to resolve shared plugins across projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,11 @@
+plugins {
+    id 'io.micronaut.application' version '4.4.4' apply false
+    id 'io.micronaut.aot' version '4.4.4' apply false
+    id 'com.github.johnrengelman.shadow' version '7.1.2' apply false
+}
+
+subprojects {
+    repositories {
+        mavenCentral()
+    }
+}


### PR DESCRIPTION
## Pull Request Summary

A `build.gradle` file in the project root was added. This solves the problem, which was of duplicate plugin usage, since both the `pi4micronaut-utils` and `components` projects share some plugins in their Gradle configurations. IDEs now build it right, and all previous manual building works the same.

## PR Checklist

- [x] Closes #408
- [x] Tests pass
- [x] Any related documentation has been updated, if necessary (none necessary)

## Detailed Description

IDEA and VS Code now do their internal Gradle syncing/building sucessfully. `./gradlew build` still works as before in the project root, in `pi4micronaut-utils`, and in `components`.