### PR TITLE
Make setLog private for internal testing

### DIFF
--- a/pi4micronaut-utils/src/main/java/com/opensourcewithslu/inputdevices/MicroSwitchHelper.java
+++ b/pi4micronaut-utils/src/main/java/com/opensourcewithslu/inputdevices/MicroSwitchHelper.java
@@ -67,7 +67,10 @@ public class MicroSwitchHelper {
 
 
     /**
-     * For internal use only
+     * Sets the logger object.
+     * This method is intended for internal testing purposes only.
+     * 
+     * @param log Logger object to set the logger to.
      */
     void setLog (Logger log){
         this.log = log;

--- a/pi4micronaut-utils/src/main/java/com/opensourcewithslu/inputdevices/UltraSonicSensorHelper.java
+++ b/pi4micronaut-utils/src/main/java/com/opensourcewithslu/inputdevices/UltraSonicSensorHelper.java
@@ -157,9 +157,9 @@ public class UltraSonicSensorHelper {
 
     /**
      * Sets the logger object.
+     * This method is intended for internal testing purposes only.
      *
      * @param log Logger object to set the logger to.
-     * For internal use only
      */
     //tag::method[]
     void setLog(Logger log)

--- a/pi4micronaut-utils/src/main/java/com/opensourcewithslu/outputdevices/FourDigitSevenSegmentDisplayHelper.java
+++ b/pi4micronaut-utils/src/main/java/com/opensourcewithslu/outputdevices/FourDigitSevenSegmentDisplayHelper.java
@@ -296,9 +296,9 @@ public class FourDigitSevenSegmentDisplayHelper {
 
     /**
      * Sets the logger object.
+     * This method is intended for internal testing purposes only.
      *
      * @param log Logger object to set the logger to.
-     * For internal use only
      */
     //tag::method[]
     void setLog(Logger log)

--- a/pi4micronaut-utils/src/main/java/com/opensourcewithslu/outputdevices/LEDHelper.java
+++ b/pi4micronaut-utils/src/main/java/com/opensourcewithslu/outputdevices/LEDHelper.java
@@ -85,9 +85,9 @@ public class LEDHelper {
 
     /**
      * Sets the logger object.
+     * This method is intended for internal testing purposes only.
      *
      * @param log Logger object to set the logger to.
-     * For internal use only
      */
     void setLog(Logger log) {
         this.log = log;

--- a/pi4micronaut-utils/src/main/java/com/opensourcewithslu/outputdevices/MotorHelper.java
+++ b/pi4micronaut-utils/src/main/java/com/opensourcewithslu/outputdevices/MotorHelper.java
@@ -123,9 +123,9 @@ public class MotorHelper {
 
     /**
      * Sets the logger object.
+     * This method is intended for internal testing purposes only.
      *
      * @param log Logger object to set the logger to.
-     * For internal use only
      */
     void setLog(Logger log) {
         this.log = log;

--- a/pi4micronaut-utils/src/main/java/com/opensourcewithslu/outputdevices/ServoMotorHelper.java
+++ b/pi4micronaut-utils/src/main/java/com/opensourcewithslu/outputdevices/ServoMotorHelper.java
@@ -91,9 +91,9 @@ public class ServoMotorHelper {
 
     /**
      * Sets the logger for this ServoMotorHelper instance.
+     * This method is intended for internal testing purposes only.
      *
      * @param logger the logger to be used for logging messages.
-     * For internal use only
      */
     void setLog(Logger logger) {
         log = logger;


### PR DESCRIPTION
## Pull Request Summary

This PR makes the setLog methods in helper classes (such as FourDigitSevenSegmentDisplayHelper, LEDHelper, UltraSonicSensorHelper, and ServoMotorHelper) package private instead of public.

## PR Checklist

- [x] Closes #388 
- [x] Tests pass
- [x] Any related documentation has been updated, if necessary

## Detailed Description
Previously, these methods were public so that unit tests could inject mock Logger objects. However, this made it possible for external users of the library to override the logger which is unnecessary.
They are now only accessible within the package and remain usable for internal tests.
