### PR TITLE
docs: update Home and Lab example app links

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ The existence of Pi4Micronaut is justified by the need for a robust, scalable, a
 ![Pi4Micronaut.png](Workflow_Diagram.png)
 
 ## Example Projects using Pi4Micronaut Library
-- [Home Automation](https://github.com/oss-slu/Pi4Micronaut/tree/Home_Automation)
-- [Lab Automation](https://github.com/oss-slu/Pi4Micronaut/tree/Lab_Automation)
+- [Home Automation](https://github.com/oss-slu/home_automation_rpi)
+- [Lab Automation](https://github.com/oss-slu/lab_automation_rpi)
 - [OSS SLU Checkin](https://github.com/oss-slu/SLU_OSS_CheckIn)
 
 ## Micronaut 3.7.3

--- a/pi4micronaut-utils/src/docs/asciidoc/Introduction/exampleApplications.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/Introduction/exampleApplications.adoc
@@ -9,7 +9,7 @@ If you're curious about what Pi4Micronaut is capable of, check out some of the w
 https://github.com/oss-slu/SLU_OSS_CheckIn
 
 ==== Home Automation
-https://github.com/oss-slu/Pi4Micronaut/tree/Home_Automation
+https://github.com/oss-slu/home_automation_rpi
 
 ==== Lab Automation
-https://github.com/oss-slu/Pi4Micronaut/tree/Lab_Automation
+https://github.com/oss-slu/lab_automation_rpi


### PR DESCRIPTION
## Pull Request Summary

Update the documentation links for the example applications to point to their new standalone repositories.

**Updated files**
- pi4micronaut-utils/src/docs/asciidoc/Introduction/exampleApplications.adoc
- README.md

**Old/New**
- https://github.com/oss-slu/Pi4Micronaut/tree/Home_Automation to https://github.com/oss-slu/home_automation_rpi
- https://github.com/oss-slu/Pi4Micronaut/tree/Lab_Automation to https://github.com/oss-slu/lab_automation_rpi

**Testing:**
- Manual verification: links point to the correct repositories.
<!-- Enter a brief description/summary of your PR here. What does it add, and why is it necessary? Does this new feature solve any problems or bugs? How was it tested — automated or manual software tests, physical hardware tests, or some other method or combination of testing techniques? -->

## PR Checklist

- [ ] Closes #356 
- [ ] Tests pass
- [ ] Any related documentation has been updated, if necessary

## Detailed Description

This PR implements what was requested in #356 by replacing the two example application links in the exampleApplications.adoc and top-level REAME.md with links pointing to the new repositories:

- Home Automation: oss-slu/home_automation_rpi
- Lab Automation: oss-slu/lab_automation_rpi

**Note:** I also noticed a link also pointing to the old home of the Home_Automation in **joss-paper/paper.md**.
As the issue requested changed in the README and exampleApplications.adoc, I did not modify the paper, but if you would like, I can update the old link to oss-slu/home_automation_rpi as well.
<!-- Provide a more detailed description and any additional information. -->