### PR TITLE
documentation link changed in maven repository data

### DIFF
--- a/pi4micronaut-utils/build.gradle
+++ b/pi4micronaut-utils/build.gradle
@@ -128,7 +128,7 @@ publishing {
                 name = 'pi4micronaut-utils'
                 packaging = 'jar'
                 description = 'A Java-based library that uses the Micronaut framework and Pi4J to simplify the use of electronic components connected to a Raspberry Pi through GPIO '
-                url = "https://github.com/oss-slu/Pi4Micronaut"
+                url = "https://oss-slu.github.io/Pi4Micronaut"
 
                 licenses {
                     license {


### PR DESCRIPTION
- Changed the `pom.url` in `build.gradle` from `https://github.com/oss-slu/Pi4Micronaut` to `https://oss-slu.github.io/Pi4Micronaut` to reflect the documentation site as the main project URL.
- No other metadata changes required.