### PR TITLE
RFidHelperTest class

### DIFF
--- a/pi4micronaut-utils/src/test/java/com/opensourcewithslu/inputdevices/RFidHelperTest.java
+++ b/pi4micronaut-utils/src/test/java/com/opensourcewithslu/inputdevices/RFidHelperTest.java
@@ -96,24 +96,4 @@ class RFidHelperTest {
             verify(mocked.constructed().get(0)).reset();
         }
     }
-    // Write and read Integer - verify data is preserved
-@Test
-void writeAndRead_Integer_ReturnsCorrectValue() {
-    Integer testValue = 42;
-    
-    try (MockedConstruction<RfidComponent> mocked = mockConstruction(RfidComponent.class)) {
-        RFidHelper helper = new RFidHelper(mockSpiConfig, RESET_PIN, mockContext);
-        RfidComponent component = mocked.constructed().get(0);
-        
-         //verify the write stores and read retrieves
-        
-        helper.writeToCard(testValue);
-        
-        
-        Object result = helper.readFromCard();
-        
-        
-        verify(component, times(2)).waitForAnyCard(any());
-    }
-}
 }


### PR DESCRIPTION
## Pull Request Summary

Closes #359 
 New Test class for RFidHelper

## test included 
- constructor_WithResetPin_CreatesComponent
    Verifies that the RFidHelper constructor with a reset pin creates exactly one RfidComponent instance.
  - constructor_WithoutResetPin_CreatesComponent 
    Ensures the constructor without a reset pin also creates exactly one RfidComponent.
  - constructor_NullContext_ThrowsNPE 
    Confirms that passing `null` for the `Context` throws a NullPointerException.
  - constructor_NullSpiConfig_ThrowsNPE  
    Confirms that passing null for SpiConfig throws a NullPointerException.
  - writeToCard_CallsWaitForAnyCard 
    Verifies that writeToCard() invokes waitForAnyCard() on the underlying RfidComponent.
  - readFromCard_CallsWaitForAnyCard 
    Verifies that readFromCard() invokes waitForAnyCard() on the RfidComponent.
  - resetScanner_CallsReset 
    Ensures resetScanner() calls the `reset()` method on the RfidComponent.

## all tests pass and the project builds successfully 
