### PR TITLE
automatic github release creation

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -34,10 +34,6 @@ jobs:
       - name: Execute Gradle shadowJar
         working-directory: pi4micronaut-utils
         run: ./gradlew shadowJar
-     
-      
-
-        
       - name: Upload built JAR as artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Closes issue #439 

this adds full automation for Github Releases 
- after a successful build and publish to Maven, a new job ' create-release ' runs
- Reads the version directly from `pi4micronaut-utils/gradle.properties` 
- Creates and pushes a Git tag matching that exact version
- Creates a GitHub Release using `gh release create` with:
  - `--verify-tag`
  - `--generate-notes` (auto-generated changelog)
  - Correct `-all.jar` attached as asset

### Changes
- Added artifact upload in `build-library` job
- Added new `create-release` job with full tag + release logic
- Fixed artifact download path using `working-directory`

- 
