### PR TITLE
Fix Javadocs not being generated in CI

### DIFF
--- a/pi4micronaut-utils/build.gradle
+++ b/pi4micronaut-utils/build.gradle
@@ -58,13 +58,15 @@ java {
     targetCompatibility = JavaVersion.toVersion("17")
 }
 
+tasks.register('copyJavadoc', Copy) {
+    dependsOn 'javadoc'
+    from tasks.javadoc.destinationDir
+    into "src/docs/javadoc"
+}
+
 tasks.named('build').configure {
     if (project.hasProperty('generateJavadoc') || System.getenv('CI') == 'true') {
-        dependsOn 'javadoc'
-        copy {
-            from tasks.javadoc.destinationDir
-            into "src/docs/javadoc"
-        }
+        dependsOn 'copyJavadoc'
     }
 }
 


### PR DESCRIPTION
## Pull Request Summary

Closes #445

I separated the step of copying the generated Javadoc files into the Javadoc folder into its own Gradle task. This allowed for it to propertly run when requested. I tested this by running `./gradlew build -PgenerateJavadoc=true` to see if the Javadocs are created in `pi4micronaut-utils/src/docs/javadoc`. This triggered the same `if` condition that would also run when the system environment variable `CI` is set to `true`, thus it accurately simulates the expected behavior when running in GitHub actions.

## PR Checklist

- [x] Tests pass
- [x] Any related documentation has been updated, if necessary
