### PR TITLE
Add username and email to Javadoc publishing workflow

### DIFF
--- a/.github/workflows/javadoc-gh-pages.yml
+++ b/.github/workflows/javadoc-gh-pages.yml
@@ -53,3 +53,5 @@ jobs:
           publish_dir: ./javadoc
           destination_dir: javadoc
           keep_files: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
## Pull Request Summary

Closes #445

Add username and email so that it can be added as an exclusion in the repository settings so it can override branch protections to commit directly to the `gh_pages` branch.