### PR TITLE
Rename Git tags and correct `./gradlew properties` working directory

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -97,7 +97,7 @@ jobs:
           cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
       - name: Read library version
         id: read_version
-        working-directory: pi4micronaut-utils
+        working-directory: .
         run: |
           VERSION=$(./gradlew properties | grep "^version:" | awk '{print $2}')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -105,10 +105,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: micronaut-jar
-          path: build/libs
+          path: pi4micronaut-utils/build/libs
       - name: Create GitHub Release
         run: |
           gh release create "${{ steps.read_version.outputs.version }}" \
             --verify-tag \
             --generate-notes \
-            "build/libs/pi4micronaut-utils-${{ steps.read_version.outputs.version }}-all.jar"
+            "pi4micronaut-utils/build/libs/pi4micronaut-utils-${{ steps.read_version.outputs.version }}-all.jar"


### PR DESCRIPTION
## Pull Request Summary

Closes #465

* Git tags are renamed `v1.0` -> `v1.0.0` and `v1.1` -> `v1.1.0` to follow semantic versioning.
* I verified that the `version` property in the Gradle Properties API is set to v1.1.0 with `./gradlew properties`. No changes were needed.
* I changed the working directory of `./gradlew properties` in `.github/workflows/build-reusable.yml`. The rational is that the `./gradlew final` task incrementing the version number is run in the root directory. So, the task getting the version number should also be run in the root directory.
