### PR TITLE
Fix: Add 'Improve this doc' link to buildAndRun.adoc documentation

### DIFF
--- a/pi4micronaut-utils/src/docs/asciidoc/Introduction/buildAndRun.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/Introduction/buildAndRun.adoc
@@ -152,3 +152,5 @@ curl http://localhost:8080/led/ledOn
 
 . If this command works and the LED has lit up, congratulations! You have successfully built and ran one of our components!
 
+[.text-right] https://github.com/oss-slu/Pi4Micronaut/edit/develop/pi4micronaut-utils/src/docs/asciidoc/Introduction/buildAndRun.adoc[Improve this doc]
+


### PR DESCRIPTION
## Pull Request Summary

## Pull Request Summary

Adds the missing 'Improve this doc' link to the buildAndRun.adoc documentation file.

Closes #427

## Changes

- Added `[.text-right]` formatted link to allow users to edit the documentation directly
- Link follows the AsciiDoc syntax pattern established in the issue
- Helps users contribute back to the documentation

## Testing

The documentation page rendering can be verified to ensure the link appears correctly aligned to the right side of the page.
<!-- Enter a brief description/summary of your PR here. What does it add, and why is it necessary? Does this new feature solve any problems or bugs? How was it tested — automated or manual software tests, physical hardware tests, or some other method or combination of testing techniques? -->

## PR Checklist

- [ ] Tests pass
- [ ] Any related documentation has been updated, if necessary

## Detailed Description

<!-- Provide a more detailed description and any additional information. -->
