### PR TITLE
Improve visual separation for level 3 headers in documentation

### DIFF
--- a/pi4micronaut-utils/src/docs/asciidoc/style.css
+++ b/pi4micronaut-utils/src/docs/asciidoc/style.css
@@ -193,3 +193,9 @@ th {
 	font-style: italic;
 	padding-top: 2em;
 }
+
+h3 {
+	margin-top: 30px;
+	padding-top: 10px;
+	border-top: 1px solid #e0e0e0;
+}


### PR DESCRIPTION
## Pull Request Summary

Closes #424

This PR improves the visual separation between level 3 headers in the documentation.

Previously, consecutive h3 sections were difficult to distinguish while scrolling.  
To address this, I added:

- Additional top margin
- Subtle top border
- Padding for spacing

These changes improve readability while maintaining proper header hierarchy.

## PR Checklist

- [x] Tests pass
- [x] Any related documentation has been updated, if necessary

## Detailed Description

Added margin-top, padding-top, and a subtle border-top to h3 elements in style.css inside pi4micronaut-utils/src/docs/asciidoc.

This keeps level 3 headers visually distinct without making them appear similar to level 2 headers.