### PR TITLE
Add master workflow to orchestrate AsciiDoc and Javadoc publishing

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,15 @@
+name: Publish Documentation
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+
+jobs:
+  publish-asciidoc:
+    uses: ./.github/workflows/asciidoc-build.yml
+
+  publish-javadoc:
+    needs: publish-asciidoc
+    uses: ./.github/workflows/javadoc-gh-pages.yml


### PR DESCRIPTION
Closes #462

## Summary

Converted the existing AsciiDoc and Javadoc publishing workflows into reusable workflows using `workflow_call`.

Added a new master workflow (`publish-docs.yml`) that triggers on push to the `main` and `develop` branches and sequentially invokes both documentation workflows using `needs` to control execution order.

This ensures controlled GitHub Pages publishing and prevents potential branch conflicts when both workflows affect the same publishing branch.

## Changes Made

- Updated `asciidoc-build.yml` to use `workflow_call`
- Updated `javadoc-gh-pages.yml` to use `workflow_call`
- Added `publish-docs.yml` to orchestrate documentation publishing

## Testing

Changes were validated through GitHub Actions workflow syntax and branch comparison. The workflows are now reusable and properly sequenced.