### PR TITLE
Convert javadoc publishing workflow to reusable workflow using workfl…

### DIFF
--- a/.github/workflows/javadoc-gh-pages.yml
+++ b/.github/workflows/javadoc-gh-pages.yml
@@ -4,10 +4,8 @@ permissions:
   pages: write
   id-token: write
 on:
-  push:
-    branches:
-      - main
-      - develop
+  workflow_call:
+    
 
 jobs:
   build:


### PR DESCRIPTION
…ow_call

Replaced the push trigger in javadoc-gh-pages.yml with workflow_call to make the workflow reusable.

This change allows the workflow to be invoked from a master orchestration workflow and ensures controlled execution order when combined with other documentation publishing workflows.

## Pull Request Summary

Closes #xxx <!-- Add the issue number here -->

*A brief description/summary of your PR. What does it add, and why is it necessary? Does this new feature solve any problems or bugs? How was it tested — automated or manual software tests, physical hardware tests, or some other method or combination of testing techniques?*

## PR Checklist

- [ ] Tests pass
- [ ] Any related documentation has been updated, if necessary

## Detailed Description

*A more detailed description and any additional information.*