### PR TITLE
Separate asciidoc publish to separate workflow

### DIFF
--- a/.github/workflows/asciidoc-build.yml
+++ b/.github/workflows/asciidoc-build.yml
@@ -16,10 +16,10 @@ jobs:
     name: ASCII DOC build
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Get build container
       id: adocbuild
-      uses: tonynv/asciidoctor-action@master
+      uses: tonynv/asciidoctor-action@v2
       with:
           program: "./gradlew asciidoctor"
     - name: Upload AsciiDoc output

--- a/.github/workflows/asciidoc-build.yml
+++ b/.github/workflows/asciidoc-build.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Get build container
-        id: adocbuild
         uses: tonynv/asciidoctor-action@v2
         with:
             program: "./gradlew asciidoctor"

--- a/.github/workflows/asciidoc-build.yml
+++ b/.github/workflows/asciidoc-build.yml
@@ -22,3 +22,8 @@ jobs:
       uses: tonynv/asciidoctor-action@master
       with:
           program: "./gradlew asciidoctor"
+    - name: Upload AsciiDoc output
+      uses: actions/upload-artifact@v4
+      with:
+        name: asciidoc-output
+        path: pi4micronaut-utils/build/docs/asciidoc/

--- a/.github/workflows/asciidoc-build.yml
+++ b/.github/workflows/asciidoc-build.yml
@@ -3,8 +3,12 @@ name: build adocs
 on:
   push:
     branches:
-    - main
-    - develop
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+  workflow_call:
 
 jobs:
   adoc_build:
@@ -18,10 +22,3 @@ jobs:
       uses: tonynv/asciidoctor-action@master
       with:
           program: "./gradlew asciidoctor"
-    - name: Deploy docs to ghpages
-      uses: peaceiris/actions-gh-pages@v3
-      with: 
-        deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-        publish_branch: gh-pages
-        publish_dir: ./pi4micronaut-utils/build/docs/asciidoc/
-

--- a/.github/workflows/asciidoc-build.yml
+++ b/.github/workflows/asciidoc-build.yml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     name: ASCII DOC build
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    - name: Get build container
-      id: adocbuild
-      uses: tonynv/asciidoctor-action@v2
-      with:
-          program: "./gradlew asciidoctor"
-    - name: Upload AsciiDoc output
-      uses: actions/upload-artifact@v4
-      with:
-        name: asciidoc-output
-        path: pi4micronaut-utils/build/docs/asciidoc/
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Get build container
+        id: adocbuild
+        uses: tonynv/asciidoctor-action@v2
+        with:
+            program: "./gradlew asciidoctor"
+      - name: Upload AsciiDoc output
+        uses: actions/upload-artifact@v4
+        with:
+          name: asciidoc-output
+          path: pi4micronaut-utils/build/docs/asciidoc/

--- a/.github/workflows/asciidoc-publish.yml
+++ b/.github/workflows/asciidoc-publish.yml
@@ -1,12 +1,7 @@
 name: publish adocs
-
-on:
-  push:
-    branches:
-      - main
-
 permissions:
   contents: read
+on: workflow_call
 
 jobs:
   build:

--- a/.github/workflows/asciidoc-publish.yml
+++ b/.github/workflows/asciidoc-publish.yml
@@ -19,7 +19,7 @@ jobs:
         name: asciidoc-output
         path: pi4micronaut-utils/build/docs/asciidoc/
     - name: Deploy docs to ghpages
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
         publish_branch: gh-pages

--- a/.github/workflows/asciidoc-publish.yml
+++ b/.github/workflows/asciidoc-publish.yml
@@ -24,3 +24,4 @@ jobs:
         deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
         publish_branch: gh-pages
         publish_dir: ./pi4micronaut-utils/build/docs/asciidoc/
+        keep_files: true

--- a/.github/workflows/asciidoc-publish.yml
+++ b/.github/workflows/asciidoc-publish.yml
@@ -1,11 +1,7 @@
 name: publish adocs
 permissions:
   contents: read
-on:
-  workflow_call:
-    secrets:
-      ACTIONS_DEPLOY_KEY:
-        required: true
+on: workflow_call
 
 jobs:
   build:

--- a/.github/workflows/asciidoc-publish.yml
+++ b/.github/workflows/asciidoc-publish.yml
@@ -13,6 +13,11 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+    - name: Download AsciiDoc output
+      uses: actions/download-artifact@v4
+      with:
+        name: asciidoc-output
+        path: pi4micronaut-utils/build/docs/asciidoc/
     - name: Deploy docs to ghpages
       uses: peaceiris/actions-gh-pages@v3
       with:

--- a/.github/workflows/asciidoc-publish.yml
+++ b/.github/workflows/asciidoc-publish.yml
@@ -1,4 +1,4 @@
-name: publish adocs
+name: Publish AsciiDoc
 permissions:
   contents: read
 on:

--- a/.github/workflows/asciidoc-publish.yml
+++ b/.github/workflows/asciidoc-publish.yml
@@ -1,7 +1,11 @@
 name: publish adocs
 permissions:
   contents: read
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      ACTIONS_DEPLOY_KEY:
+        required: true
 
 jobs:
   build:
@@ -11,17 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     name: ASCII DOC publish
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    - name: Download AsciiDoc output
-      uses: actions/download-artifact@v4
-      with:
-        name: asciidoc-output
-        path: pi4micronaut-utils/build/docs/asciidoc/
-    - name: Deploy docs to ghpages
-      uses: peaceiris/actions-gh-pages@v4
-      with:
-        deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-        publish_branch: gh-pages
-        publish_dir: ./pi4micronaut-utils/build/docs/asciidoc/
-        keep_files: true
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Download AsciiDoc output
+        uses: actions/download-artifact@v4
+        with:
+          name: asciidoc-output
+          path: pi4micronaut-utils/build/docs/asciidoc/
+      - name: Deploy docs to ghpages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          publish_branch: gh-pages
+          publish_dir: ./pi4micronaut-utils/build/docs/asciidoc/
+          keep_files: true

--- a/.github/workflows/asciidoc-publish.yml
+++ b/.github/workflows/asciidoc-publish.yml
@@ -1,7 +1,11 @@
 name: publish adocs
 permissions:
   contents: read
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      ACTIONS_DEPLOY_KEY:
+        required: true
 
 jobs:
   build:

--- a/.github/workflows/asciidoc-publish.yml
+++ b/.github/workflows/asciidoc-publish.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: ./.github/workflows/asciidoc-build.yml

--- a/.github/workflows/asciidoc-publish.yml
+++ b/.github/workflows/asciidoc-publish.yml
@@ -1,0 +1,23 @@
+name: publish adocs
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: ./.github/workflows/asciidoc-build.yml
+  adoc_publish:
+    needs: build
+    runs-on: ubuntu-latest
+    name: ASCII DOC publish
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Deploy docs to ghpages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        publish_branch: gh-pages
+        publish_dir: ./pi4micronaut-utils/build/docs/asciidoc/

--- a/.github/workflows/asciidoc-publish.yml
+++ b/.github/workflows/asciidoc-publish.yml
@@ -12,7 +12,7 @@ jobs:
     name: ASCII DOC publish
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Deploy docs to ghpages
       uses: peaceiris/actions-gh-pages@v3
       with:

--- a/.github/workflows/javadoc-gh-pages.yml
+++ b/.github/workflows/javadoc-gh-pages.yml
@@ -40,7 +40,6 @@ jobs:
         with:
           name: javadoc
           path: ./javadoc
-          retention-days: 1
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/javadoc-gh-pages.yml
+++ b/.github/workflows/javadoc-gh-pages.yml
@@ -4,7 +4,10 @@ permissions:
   pages: write
   id-token: write
 on:
-  workflow_call: 
+  workflow_call:
+    secrets:
+      GITHUB_TOKEN:
+        required: true
 
 jobs:
   build:

--- a/.github/workflows/javadoc-gh-pages.yml
+++ b/.github/workflows/javadoc-gh-pages.yml
@@ -5,9 +5,6 @@ permissions:
   id-token: write
 on:
   workflow_call:
-    secrets:
-      GITHUB_TOKEN:
-        required: true
 
 jobs:
   build:

--- a/.github/workflows/javadoc-gh-pages.yml
+++ b/.github/workflows/javadoc-gh-pages.yml
@@ -42,7 +42,6 @@ jobs:
           path: ./javadoc
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
-        if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./javadoc

--- a/.github/workflows/javadoc-gh-pages.yml
+++ b/.github/workflows/javadoc-gh-pages.yml
@@ -43,7 +43,7 @@ jobs:
           retention-days: 1
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
-        if: github.ref == 'refs/heads/develop'
+        if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./javadoc

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,11 +4,10 @@ on:
   push:
     branches:
       - main
-      - develop
 
 jobs:
   publish-asciidoc:
-    uses: ./.github/workflows/asciidoc-build.yml
+    uses: ./.github/workflows/asciidoc-publish.yml
 
   publish-javadoc:
     needs: publish-asciidoc

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,5 +1,6 @@
 name: Publish Documentation
-
+permissions:
+  contents: write
 on:
   push:
     branches:
@@ -8,6 +9,8 @@ on:
 jobs:
   publish-asciidoc:
     uses: ./.github/workflows/asciidoc-publish.yml
+    secrets:
+      ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
 
   publish-javadoc:
     needs: publish-asciidoc

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -5,14 +5,9 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-
 jobs:
   publish-asciidoc:
     uses: ./.github/workflows/asciidoc-publish.yml
-    secrets:
-      ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
 
   publish-javadoc:
     needs: publish-asciidoc

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -5,9 +5,14 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   publish-asciidoc:
     uses: ./.github/workflows/asciidoc-publish.yml
+    secrets:
+      ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
 
   publish-javadoc:
     needs: publish-asciidoc


### PR DESCRIPTION
## Pull Request Summary

Closes #433 <!-- Add the issue number here -->

*A brief description/summary of your PR. What does it add, and why is it necessary? Does this new feature solve any problems or bugs? How was it tested — automated or manual software tests, physical hardware tests, or some other method or combination of testing techniques?*

ASCIIDoc publishing has been separated from the workflow that builds them. So now:

* The build workflow runs on PR to `main` or `develop`, and on push to `develop`. This allows the build to be validated at those times.
* The new workflow to both build and publish runs only on push to `main`. This way, new documentation is published only when a new version of the library is publicly released.