### PR TITLE
Bump this project to Java 25 and Pi4J 4 so it can be used on Raspberry Pi 5

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
       - name: Change wrapper permissions
         run: chmod +x pi4micronaut-utils/gradlew
       - name: Setup Gradle
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
       - name: Change wrapper permissions
         run: chmod +x pi4micronaut-utils/gradlew
@@ -89,10 +89,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
       - name: Change wrapper permissions
         run: chmod +x pi4micronaut-utils/gradlew

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -20,10 +20,10 @@ jobs:
                 os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
       - name: Change wrapper permissions
         run: chmod +x pi4micronaut-utils/gradlew

--- a/.github/workflows/javadoc-gh-pages.yml
+++ b/.github/workflows/javadoc-gh-pages.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
       - name: Change wrapper permissions
         run: chmod +x pi4micronaut-utils/gradlew

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 ![GitHub License](https://img.shields.io/github/license/oss-slu/Pi4Micronaut)
 [![Documentation](https://img.shields.io/badge/Documentation-8D021F)](https://oss-slu.github.io/Pi4Micronaut/)
 
-
 [![Chat on Slack](https://img.shields.io/badge/Chat_on-Slack-4A154B?logo=slack)](https://join.slack.com/t/oswslu/shared_invite/zt-24f0qhjbo-NkSfQ4LOg5wXxBdxP4vzfA)
 [![Donate to OSS](https://img.shields.io/badge/Donate_to-OSS-003AA6)](https://oss-slu.github.io/connect_with/donate)
 [![Unity Foundation](https://img.shields.io/badge/Unity_Foundation-unityfoundation.io-blue)](https://unityfoundation.io)
@@ -16,7 +15,7 @@ Pi4Micronaut is an innovative Java library crafted for developers who aim to bui
 
 The existence of Pi4Micronaut is justified by the need for a robust, scalable, and efficient way to bridge the gap between enterprise-grade software and the physical world of hardware. It is particularly valuable for projects that demand both the high-performance, microservices-oriented capabilities of the Micronaut framework and the versatile hardware interaction that the Raspberry Pi offers. Whether it's for home automation, industrial monitoring, or educational purposes, Pi4Micronaut empowers developers to deliver reliable and sophisticated IoT applications that can run headless on a Raspberry Pi or be managed remotely, providing convenience, control, and customization to the end-users.
 
-**Note:** Pi4Micronaut doesn't work with the latest Raspberry Pi 5 because of its whole new architecture. The Pi4J and pigpio libraries doesn't provide support for Pi 5 yet. Look out for the latest version of Pi4J to work with Pi 5 in the future.
+**Note:** Pi4Micronaut also works with the latest Raspberry Pi 5, although it has a new GPIO architecture. The Pi4J library V4+ is based on Java 25 and uses the Foreign Function and Memory API to handle the GPIOs, which makes it independent of the Raspberry Pi system and can even be used on other single-board computers.
 
 ### Information
 
@@ -51,7 +50,6 @@ The existence of Pi4Micronaut is justified by the need for a robust, scalable, a
 - **Type:** IoT (Raspberry Pi)
 - **License:** [Apache License 2.0](https://opensource.org/license/apache-2-0/)
 
-
 ## Pi4Micronaut
 - [Link to Pi4Micronaut Documentation](https://oss-slu.github.io/Pi4Micronaut/)
 - [API Reference](https://oss-slu.github.io/Pi4Micronaut/javadoc/index.html)
@@ -71,7 +69,7 @@ The existence of Pi4Micronaut is justified by the need for a robust, scalable, a
 - [Micronaut Guides](https://docs.micronaut.io/latest/guide/index.html)
 - [Micronaut HTTP Client documentation](https://docs.micronaut.io/latest/guide/index.html#httpClient)
 
-## Pi4J 2.4.0
+## Pi4J 4.0.2
 - [Pi4j Documentation](https://pi4j.com/documentation/)
 
 ## Shadow Gradle 7.1.2

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    id 'io.micronaut.application' version '4.4.4' apply false
-    id 'io.micronaut.aot' version '4.4.4' apply false
-    id 'com.github.johnrengelman.shadow' version '7.1.2' apply false
+    id 'io.micronaut.application' version '5.0.2' apply false
+    id 'io.micronaut.aot' version '5.0.2' apply false
+    id 'com.gradleup.shadow' version '9.6.1' apply false
     id("com.netflix.nebula.release") version "20.2.0"
 }
 

--- a/components/build.gradle
+++ b/components/build.gradle
@@ -36,8 +36,8 @@ java {
 
 tasks.named('test') {
     useJUnitPlatform()
-    // The only test (ComponentsTest) boots an embedded app that needs Pi hardware, so it is disabled.
-    // Gradle 9 fails a test task that discovers no tests unless this is turned off.
+    // The only test class (ComponentsTest) has its @Test annotation commented out, so no tests are
+    // discovered. Gradle 9 fails a test task that discovers no tests unless this is turned off.
     failOnNoDiscoveredTests = false
 }
 

--- a/components/build.gradle
+++ b/components/build.gradle
@@ -1,8 +1,8 @@
 plugins {
-    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("com.gradleup.shadow") version "9.6.1"
 //    id("io.micronaut.application") version "3.7.3"
-    id("io.micronaut.application") version "4.4.4"
-    id("io.micronaut.aot") version "4.4.4"
+    id("io.micronaut.application") version "5.0.2"
+    id("io.micronaut.aot") version "5.0.2"
 }
 
 version = "0.1"
@@ -30,8 +30,15 @@ application {
     mainClass.set("com.opensourcewithslu.components.Application")
 }
 java {
-    sourceCompatibility = JavaVersion.toVersion("21")
-    targetCompatibility = JavaVersion.toVersion("21")
+    sourceCompatibility = JavaVersion.toVersion("25")
+    targetCompatibility = JavaVersion.toVersion("25")
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+    // The only test (ComponentsTest) boots an embedded app that needs Pi hardware, so it is disabled.
+    // Gradle 9 fails a test task that discovers no tests unless this is turned off.
+    failOnNoDiscoveredTests = false
 }
 
 micronaut {

--- a/components/src/main/resources/application.yml
+++ b/components/src/main/resources/application.yml
@@ -208,7 +208,6 @@ pi4j:
       shutdown: LOW
       initial: LOW
       provider: ffm-digital-output
-    name: Digit 0
     adc-cs:
       name: ADCChipSelect
       address: 5                # <1> Specify the GPIO pin for CS (Chip Select)

--- a/components/src/main/resources/application.yml
+++ b/components/src/main/resources/application.yml
@@ -23,35 +23,35 @@ pi4j:
       name: active-buzzer        # <2>
       address: 17                # <3>
       pwmType: SOFTWARE          # <4>
-      provider: pigpio-pwm       # <5>
+      provider: ffm-pwm       # <5>
       initial: 0                 # <6>
       shutdown: 0                # <7>
     passive-buzzer:
       name: passive-buzzer
       address: 17
       pwmType: SOFTWARE
-      provider: pigpio-pwm
+      provider: ffm-pwm
       initial: 0
       shutdown: 0
     servo-motor:
       name: Servo Motor
       address: 18
       pwmType: SOFTWARE
-      provider: pigpio-pwm
+      provider: ffm-pwm
       initial: 0
       shutdown: 0
     motor:
       name: Motor
       address: 22
       pwmType: SOFTWARE
-      provider: pigpio-pwm
+      provider: ffm-pwm
       initial: 0
       shutdown: 0
     fan:
       name: FAN
       address: 18
       pwm-type: SOFTWARE
-      provider: pigpio-pwm
+      provider: ffm-pwm
       initial: 0
       shutdown: 0
   # end::pwm[]
@@ -71,91 +71,91 @@ pi4j:
       address: 4                          # <.>
       debounce: 100000                    # <.>
       pull: PULL_DOWN                     # <.>
-      provider: pigpio-digital-input      # <.>
+      provider: ffm-digital-input      # <.>
     button-input-1:
       name: Push Button Input
       address: 16
       pull: PULL_DOWN
       debounce: 30
-      provider: pigpio-digital-input
+      provider: ffm-digital-input
     button-input-2:
       name: Push Button Input
       address: 21
       pull: PULL_DOWN
       debounce: 30
-      provider: pigpio-digital-input
+      provider: ffm-digital-input
     button-input-3:
       name: Push Button Input
       address: 18
       pull: PULL_DOWN
       debounce: 30
-      provider: pigpio-digital-input
+      provider: ffm-digital-input
     slide-switch-input:
       name: Slide Switch Input
       address: 18
       pull: PULL_DOWN
       debounce: 3000
-      provider: pigpio-digital-input
+      provider: ffm-digital-input
     slide-switch-input-2:
       name: Slide Switch Input
       address: 22
       pull: PULL_DOWN
       debounce: 3000
-      provider: pigpio-digital-input
+      provider: ffm-digital-input
     touch-switch-input:
       name: Touch Switch Input
       address: 17
       pull: PULL_DOWN
       debounce: 200000
-      provider: pigpio-digital-input
+      provider: ffm-digital-input
     micro-switch:
       name: Micro Switch
       address: 19
       pull: PULL_DOWN
       debounce: 200000
-      provider: pigpio-digital-input
+      provider: ffm-digital-input
     pir-sensor:
       name: PIR Sensor
       address: 13
       pull: PULL_DOWN
       debounce: 30000
-      provider: pigpio-digital-input
+      provider: ffm-digital-input
     ultra-sonic-echo:
       name: UltraSonic Sensor Input
       address: 24
       pull: PULL_DOWN
       debounce: 3000
-      provider: pigpio-digital-input
+      provider: ffm-digital-input
     tilt-switch-input:
       name: Tilt Switch Input
       address: 17
       pull: PULL_DOWN
       debounce: 5000
-      provider: pigpio-digital-input
+      provider: ffm-digital-input
     speed-sensor:
       name: Speed Sensor           # <1>
       address: 17                 # <2>
       pulses-per-revolution: 20    # <3>
-      provider: pigpio-digital-input # <4>
+      provider: ffm-digital-input # <4>
       debounce: 500                # <5>
     adc-dout:
       name: ADC DataOut
       address: 8                # <4> Specify the GPIO pin for Data Out
       pull: PULL_DOWN           # Configure pull-up or pull-down as needed
       debounce: 100             # Optional debounce time for stable readings
-      provider: pigpio-digital-input
+      provider: ffm-digital-input
     reed-switch-input:
       name: Reed Switch
       address: 17
       pull: PULL_UP
       debounce: 200
-      provider: pigpio-digital-input
+      provider: ffm-digital-input
     ir-obstacle-input:
       name: IR Obstacle Avoidance Sensor
       address: 17
       pull: PULL_UP
       debounce: 10000
-      provider: pigpio-digital-input
+      provider: ffm-digital-input
   # end::digitalInput[]
 
   # tag::digitalOutput[]
@@ -165,60 +165,60 @@ pi4j:
       address: 17                           # <3>
       shutdown: LOW                        # <4>
       initial: LOW                         # <5>
-      provider: pigpio-digital-output       # <6>
+      provider: ffm-digital-output       # <6>
     led2:
       name: LED Output
       address: 26
       shutdown: HIGH
       initial: HIGH
-      provider: pigpio-digital-output
+      provider: ffm-digital-output
     led3:
       name: LED Output
       address: 22
       shutdown: LOW
       initial: HIGH
-      provider: pigpio-digital-output
+      provider: ffm-digital-output
     led4:
       name: LED Output
       address: 27
       shutdown: HIGH
       initial: HIGH
-      provider: pigpio-digital-output
+      provider: ffm-digital-output
     photo-resistor-output:
       name: Photo Resistor Output
       address: 27
       shutdown: LOW
       initial: HIGH
-      provider: pigpio-digital-output
+      provider: ffm-digital-output
     ultra-sonic-trig:
       name: UltraSonic Sensor Output
       address: 23
       shutdown: LOW
       initial: LOW
-      provider: pigpio-digital-output
+      provider: ffm-digital-output
     motor-pin-1:
       name: Motor Pin 1
       address: 17
       shutdown: HIGH
       initial: HIGH
-      provider: pigpio-digital-output
+      provider: ffm-digital-output
     motor-pin-2:
       name: Motor Pin 2
       address: 27
       shutdown: LOW
       initial: LOW
-      provider: pigpio-digital-output
+      provider: ffm-digital-output
     name: Digit 0
     adc-cs:
       name: ADCChipSelect
       address: 5                # <1> Specify the GPIO pin for CS (Chip Select)
       initial: HIGH             # Initial state for Chip Select (could be HIGH or LOW based on needs)
-      provider: pigpio-digital-output
+      provider: ffm-digital-output
     adc-clk:
       name: ADCClock
       address: 6                # <2> Specify the GPIO pin for CLK (Clock)
       initial: LOW              # Initial state for Clock
-      provider: pigpio-digital-output
+      provider: ffm-digital-output
     adc-din:
       name: ADCDataIn
       address: 7                # <3> Specify the GPIO pin for Data In
@@ -228,43 +228,43 @@ pi4j:
       address: 17
       shutdown: LOW
       initial: LOW
-      provider: pigpio-digital-output
+      provider: ffm-digital-output
     digit-1:
       name: Digit 1
       address: 27
       shutdown: LOW
       initial: LOW
-      provider: pigpio-digital-output
+      provider: ffm-digital-output
     digit-2:
       name: Digit 2
       address: 22
       shutdown: LOW
       initial: LOW
-      provider: pigpio-digital-output
+      provider: ffm-digital-output
     digit-3:
       name: Digit 3
       address: 10
       shutdown: LOW
       initial: LOW
-      provider: pigpio-digital-output
+      provider: ffm-digital-output
     sdi:
       name: SDI
       address: 24
       shutdown: LOW
       initial: LOW
-      provider: pigpio-digital-output
+      provider: ffm-digital-output
     rclk:
       name: RCLK
       address: 23
       shutdown: LOW
       initial: LOW
-      provider: pigpio-digital-output
+      provider: ffm-digital-output
     srclk:
       name: SRCLK
       address: 18
       shutdown: LOW
       initial: LOW
-      provider: pigpio-digital-output
+      provider: ffm-digital-output
   # end::digitalOutput[]
 
   # tag::multiInput[]
@@ -276,7 +276,7 @@ pi4j:
       pulls: PULL_DOWN,PULL_UP,PULL_UP     # <.>
       shutdown: LOW                        # <.>
       initial: HIGH                        # <.>
-      provider: pigpio-digital-input       # <.>
+      provider: ffm-digital-input       # <.>
     rotary-encoder-2:
       name: Rotary Encoder 2
       addresses: 12, 16, 20
@@ -284,7 +284,7 @@ pi4j:
       pulls: PULL_DOWN, PULL_UP, PULL_UP
       shutdown: LOW
       initial: HIGH
-      provider: pigpio-digital-input
+      provider: ffm-digital-input
   # end::multiInput[]
 
   # tag::multiPWM[]
@@ -293,14 +293,14 @@ pi4j:
       name: RGB LED                             # <.>
       addresses: 17, 18, 27                     # <.>
       pwmTypes: SOFTWARE, SOFTWARE, SOFTWARE    # <.>
-      provider: pigpio-pwm                      # <.>
+      provider: ffm-pwm                      # <.>
       initials: 0, 0, 0                         # <.>
       shutdowns: 0, 0, 0                        # <.>
     rgb-led-2:
       name: RGB LED 2
       addresses: 18, 27, 22
       pwmTypes: SOFTWARE, SOFTWARE, SOFTWARE
-      provider: pigpio-pwm
+      provider: ffm-pwm
       initials: 0, 0, 0
       shutdowns: 0, 0, 0
   # end::multiPWM[]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/pi4micronaut-utils/build.gradle
+++ b/pi4micronaut-utils/build.gradle
@@ -1,8 +1,8 @@
 plugins {
-    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("com.gradleup.shadow") version "9.6.1"
 //    id("io.micronaut.library") version "3.7.3"
-    id("io.micronaut.application") version "4.4.4"
-    id("io.micronaut.aot") version "4.4.4"
+    id("io.micronaut.application") version "5.0.2"
+    id("io.micronaut.aot") version "5.0.2"
     id 'maven-publish'
     id 'signing'
     id 'org.asciidoctor.jvm.convert' version '4.0.2'
@@ -35,17 +35,16 @@ dependencies {
     implementation 'org.fusesource.jansi:jansi:2.4.0'
     implementation files("libs/crowpi.jar", "libs/components.jar")
     runtimeOnly "org.yaml:snakeyaml:2.0"
-    api 'com.pi4j:pi4j-core:2.4.0'
-    api 'com.pi4j:pi4j-plugin-raspberrypi:2.4.0'
-    api 'com.pi4j:pi4j-plugin-pigpio:2.4.0'
+    api 'com.pi4j:pi4j-core:4.0.2'
+    api 'com.pi4j:pi4j-plugin-ffm:4.0.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.1'
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testImplementation("org.mockito:mockito-core:5.18.0")
+    testImplementation("org.mockito:mockito-core:5.23.0")
     testImplementation(platform("org.junit:junit-bom:5.11.0"))
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
-    testImplementation("org.mockito:mockito-junit-jupiter:5.18.0")
+    testImplementation("org.mockito:mockito-junit-jupiter:5.23.0")
 }
 
 application {
@@ -53,8 +52,8 @@ application {
 }
 
 java {
-    sourceCompatibility = JavaVersion.toVersion("21")
-    targetCompatibility = JavaVersion.toVersion("21")
+    sourceCompatibility = JavaVersion.toVersion("25")
+    targetCompatibility = JavaVersion.toVersion("25")
 }
 
 tasks.register('copyJavadoc', Copy) {

--- a/pi4micronaut-utils/src/docs/asciidoc/Introduction/buildAndRun.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/Introduction/buildAndRun.adoc
@@ -70,12 +70,7 @@ To verify installation, run
 java --version
 ----
 +
-Finally, install pigpio
-+
-[source, bash]
-----
-sudo apt-get install pigpio
-----
+No additional native library needs to be installed: the Pi4J FFM provider communicates directly with the Linux GPIO character device (gpiochip). Make sure the user running the application has access to the GPIO devices (for example, by being a member of the `gpio` group).
 
 ==== Enabling Different Communication Protocols
 . In the Pi4Micronaut library, we have used different communication protocols, such as I2C, SPI, etc.

--- a/pi4micronaut-utils/src/docs/asciidoc/Introduction/howToUsePi4Micronaut.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/Introduction/howToUsePi4Micronaut.adoc
@@ -53,7 +53,7 @@ pi4j:
             address: 17
             shutdown: LOW
             initial: LOW
-            provider: pigpio-digital-output
+            provider: ffm-digital-output
 ----
 +
 Here we are specifying a led as a digital output type with name LED, BCM address 17, etc

--- a/pi4micronaut-utils/src/docs/asciidoc/components/commun_WithHardware.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/commun_WithHardware.adoc
@@ -31,6 +31,6 @@ Note: A BCM numbering system should be used. More info can be found at https://p
 - The communication type configuration classes are in our utilities folder which define the methods and attributes which are used in the factory classes
  to apply the specifics listed in the yml file.
 - The factory classes create a context with all the beans which can be used by the different hardware components.
-- When the JAR file is ran on the RaspberryPi, the beans interact with the pigpio library to communicate with the GPIO pins.
+- When the JAR file is ran on the RaspberryPi, the beans interact with the Pi4J FFM provider, which uses the Linux GPIO character device (gpiochip) to communicate with the GPIO pins.
 
 image:Config_Workflow.png[]

--- a/pi4micronaut-utils/src/docs/asciidoc/components/commun_WithHardware/digitalInput.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/commun_WithHardware/digitalInput.adoc
@@ -15,7 +15,7 @@ Each component will need
 * address: GPIO BCM pin associated with component
 * debounce: value that determines the threshold for noise from the component
 * pull: Either PULL_UP or PULL_DOWN depending on component
-* provider: pigpio-digital-input
+* provider: ffm-digital-input
 
 .Example Digital Input declaration
 [source,yaml]
@@ -28,4 +28,4 @@ include::../../../../../../components/src/main/resources/application.yml[tags=di
 <.> Address of connected GPIO pin
 <.> Debounce value
 <.> Pull value (PULL_UP or PULL_DOWN)
-<.> Provider (pigpio-digital-input)
+<.> Provider (ffm-digital-input)

--- a/pi4micronaut-utils/src/docs/asciidoc/components/commun_WithHardware/digitalOutput.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/commun_WithHardware/digitalOutput.adoc
@@ -16,7 +16,7 @@ Each component will need
 * address: GPIO BCM pin associated with component
 * initial: Initial value, either LOW or HIGH
 * shutdown: State to take when program successfully shuts down properly, either LOW or HIGH
-* provider: pigpio-digital-output
+* provider: ffm-digital-output
 
 .Example Digital Output declaration
 [source,yaml]
@@ -28,4 +28,4 @@ include::../../../../../../components/src/main/resources/application.yml[tags=di
 <3> Address of connected GPIO BCM pin
 <4> Value to have on shutdown (HIGH = Off, LOW = On)
 <5> Value to have on startup
-<6> Provider (pigpio-digital-output)
+<6> Provider (ffm-digital-output)

--- a/pi4micronaut-utils/src/docs/asciidoc/components/commun_WithHardware/pwm.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/commun_WithHardware/pwm.adoc
@@ -16,7 +16,7 @@ Each component will need:
 * name: Name of the component
 * BCM address: GPIO pin associated with component
 * pwmType: Either SOFTWARE or HARDWARE based upon which type of PWM you wish to use
-* provider: pigpio-pwm
+* provider: ffm-pwm
 * initial: Initial value on startup
 * shutdown: Final value at shut down
 
@@ -29,6 +29,6 @@ include::../../../../../../components/src/main/resources/application.yml[tags=pw
 <2> Component Name
 <3> BCM Address of connected GPIO pin
 <4> PWM Type (HARDWARE or SOFTWARE)
-<5> Provider (pigpio-digital-output)
+<5> Provider (ffm-digital-output)
 <6> Value to have on start up
 <7> Value to have on shut down

--- a/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/IRObstacleAvoidance.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/IRObstacleAvoidance.adoc
@@ -125,7 +125,7 @@ pi4j:
       address: 17
       pull: PULL_UP
       debounce: 10000
-      provider: pigpio-digital-input
+      provider: ffm-digital-input
 ----
 
 ===== Constructor and Methods

--- a/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/microSwitch.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/microSwitch.adoc
@@ -94,14 +94,14 @@ digital-output:
     address: 22
     shutdown: HIGH
     initial: HIGH
-    provider: pigpio-digital-output
+    provider: ffm-digital-output
 
     led2:
     name: LED Output
     address: 27
     shutdown: HIGH
     initial: HIGH
-    provider: pigpio-digital-output
+    provider: ffm-digital-output
 ----
 So, the output of the LEDs is connected to GPIO 22 and GPIO 27 respectively.
 
@@ -114,7 +114,7 @@ The YAML configuration for the micro switch is as follows:
       address: 17
       pull: PULL_DOWN
       debounce: 200000
-      provider: pigpio-digital-input
+      provider: ffm-digital-input
 ----
 So, the input of the micro switch is connected to GPIO 17.
 

--- a/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/photoresistorSensor.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/photoresistorSensor.adoc
@@ -108,7 +108,7 @@ The PhotoResistor as it appears in the YAML file:
       address: 4                          # <.>
       debounce: 100000                    # <.>
       pull: PULL_DOWN                     # <.>
-      provider: pigpio-digital-input      # <.>
+      provider: ffm-digital-input      # <.>
 
   digital-output:
     photo-resistor-output:
@@ -116,7 +116,7 @@ The PhotoResistor as it appears in the YAML file:
       address: 27
       shutdown: LOW
       initial: HIGH
-      provider: pigpio-digital-output
+      provider: ffm-digital-output
 
 ----
 

--- a/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/pirSensor.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/pirSensor.adoc
@@ -80,7 +80,7 @@ digital-input:
       address: 13
       pull: PULL_DOWN
       debounce: 30000
-      provider: pigpio-digital-input
+      provider: ffm-digital-input
 ----
 
 ===== Constructor and Methods

--- a/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/pushButton.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/pushButton.adoc
@@ -57,7 +57,7 @@ digital-output:
     address: 17
     shutdown: LOW
     initial: LOW
-    provider: pigpio-digital-output
+    provider: ffm-digital-output
 ----
 So the LED would be connected to GPIO 17.
 
@@ -71,7 +71,7 @@ digital-input:
       address: 18
       pull: PULL_DOWN
       debounce: 30
-      provider: pigpio-digital-input
+      provider: ffm-digital-input
 ----
 So the push button would be connected to GPIO 18.
 

--- a/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/reedSwitch.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/reedSwitch.adoc
@@ -90,7 +90,7 @@ digital-input:
     address: 17
     pull: PULL_UP
     debounce: 200
-    provider: pigpio-digital-input
+    provider: ffm-digital-input
 ----
 
 The YAML configuration for the first LED:
@@ -103,7 +103,7 @@ digital-output:
     address: 22
     shutdown: LOW
     initial: HIGH
-    provider: pigpio-digital-output
+    provider: ffm-digital-output
 ----
 
 The YAML configuration for the second LED:
@@ -116,7 +116,7 @@ digital-output:
     address: 27
     shutdown: HIGH
     initial: HIGH
-    provider: pigpio-digital-output
+    provider: ffm-digital-output
 ----
 
 

--- a/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/rotaryEncoder.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/rotaryEncoder.adoc
@@ -80,7 +80,7 @@ multi-digital-input:
     pulls: PULL_DOWN,PULL_UP,PULL_UP
     shutdown: LOW
     initial: HIGH
-    provider: pigpio-digital-input
+    provider: ffm-digital-input
 ----
 
 the sw pin would be the one connected to GPIO 27, the clk pin would be connected to GPIO 18, and the dt pin would connect to GPIO 17. All lists of values for Rotary Encoder components will follow the same order.

--- a/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/slideSwitch.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/slideSwitch.adoc
@@ -69,14 +69,14 @@ digital-input:
       address: 18
       pull: PULL_DOWN
       debounce: 3000
-      provider: pigpio-digital-input
+      provider: ffm-digital-input
 
     slide-switch-input-2:
       name: Slide Switch Input
       address: 22
       pull: PULL_DOWN
       debounce: 3000
-      provider: pigpio-digital-input
+      provider: ffm-digital-input
 ----
 
 *Note:* There are two slide switches, one that uses GPIO 18 and the other uses GPIO 22.

--- a/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/speedSensor.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/speedSensor.adoc
@@ -92,7 +92,7 @@ digital-input:
     name: Speed Sensor
     address: 17
     pulses-per-revolution: 20
-    provider: pigpio-digital-input
+    provider: ffm-digital-input
     debounce: 500
 ----
 

--- a/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/tiltSwitch.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/tiltSwitch.adoc
@@ -90,7 +90,7 @@ digital-output:
     address: 26
     shutdown: HIGH
     initial: HIGH
-    provider: pigpio-digital-output
+    provider: ffm-digital-output
 ----
 So, the output of the LED is connected to GPIO 26.
 
@@ -104,7 +104,7 @@ digital-input:
     address: 17
     pull: PULL_DOWN
     debounce: 5000
-    provider: pigpio-digital-input
+    provider: ffm-digital-input
 ----
 So, the input of the tilt switch is connected to GPIO 17.
 

--- a/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/touchSwitch.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/touchSwitch.adoc
@@ -91,7 +91,7 @@ digital-output:
     address: 26
     shutdown: HIGH
     initial: HIGH
-    provider: pigpio-digital-output
+    provider: ffm-digital-output
 ----
 So, the output of the LED is connected to GPIO 26.
 
@@ -105,7 +105,7 @@ digital-input:
     address: 17
     pull: PULL_DOWN
     debounce: 200000
-    provider: pigpio-digital-input
+    provider: ffm-digital-input
 ----
 So, the input of the touch switch is connected to GPIO 17.
 

--- a/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/ultraSonicSensor.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/inputComponents/ultraSonicSensor.adoc
@@ -73,7 +73,7 @@ digital-input:
     address: 24
     pull: PULL_DOWN
     debounce: 3000
-    provider: pigpio-digital-input
+    provider: ffm-digital-input
 
 digital-output:
   ultra-sonic-trig:
@@ -81,7 +81,7 @@ digital-output:
     address: 23
     shutdown: LOW
     initial: LOW
-    provider: pigpio-digital-output
+    provider: ffm-digital-output
 ----
 
 ===== Constructor and Methods

--- a/pi4micronaut-utils/src/docs/asciidoc/components/outputComponents/activebuzzer.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/outputComponents/activebuzzer.adoc
@@ -104,7 +104,7 @@ pwm:
     name: active-buzzer
     address: 17
     pwmType: SOFTWARE
-    provider: pigpio-pwm
+    provider: ffm-pwm
     initial: 0
     shutdown: 0
 ----

--- a/pi4micronaut-utils/src/docs/asciidoc/components/outputComponents/fan.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/outputComponents/fan.adoc
@@ -52,7 +52,7 @@ pwm:
     name: FAN
     address: 18
     pwm-type: SOFTWARE
-    provider: pigpio-pwm
+    provider: ffm-pwm
     initial: 0
     shutdown: 0
 ----

--- a/pi4micronaut-utils/src/docs/asciidoc/components/outputComponents/fourDigitSevenSegment.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/outputComponents/fourDigitSevenSegment.adoc
@@ -131,43 +131,43 @@ digital-output:
     address: 17
     shutdown: LOW
     initial: LOW
-    provider: pigpio-digital-output
+    provider: ffm-digital-output
   digit-1:
     name: Digit 1
     address: 27
     shutdown: LOW
     initial: LOW
-    provider: pigpio-digital-output
+    provider: ffm-digital-output
   digit-2:
     name: Digit 2
     address: 22
     shutdown: LOW
     initial: LOW
-    provider: pigpio-digital-output
+    provider: ffm-digital-output
   digit-3:
     name: Digit 3
     address: 10
     shutdown: LOW
     initial: LOW
-    provider: pigpio-digital-output
+    provider: ffm-digital-output
   sdi:
     name: SDI
     address: 24
     shutdown: LOW
     initial: LOW
-    provider: pigpio-digital-output
+    provider: ffm-digital-output
   rclk:
     name: RCLK
     address: 23
     shutdown: LOW
     initial: LOW
-    provider: pigpio-digital-output
+    provider: ffm-digital-output
   srclk:
     name: SRCLK
     address: 18
     shutdown: LOW
     initial: LOW
-    provider: pigpio-digital-output
+    provider: ffm-digital-output
 ----
 
 ===== Constructor and Methods

--- a/pi4micronaut-utils/src/docs/asciidoc/components/outputComponents/led.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/outputComponents/led.adoc
@@ -73,13 +73,13 @@ digital-output:
     address: 17
     shutdown: LOW
     initial: LOW
-    provider: pigpio-digital-output
+    provider: ffm-digital-output
   led2:
     name: LED Output
     address: 26
     shutdown: HIGH
     initial: HIGH
-    provider: pigpio-digital-output
+    provider: ffm-digital-output
 ----
 
 

--- a/pi4micronaut-utils/src/docs/asciidoc/components/outputComponents/motor.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/outputComponents/motor.adoc
@@ -99,7 +99,7 @@ pwm:
     name: Motor
     address: 22
     pwmType: SOFTWARE
-    provider: pigpio-pwm
+    provider: ffm-pwm
     initial: 0
     shutdown: 0
 digital-output:
@@ -108,13 +108,13 @@ digital-output:
     address: 17
     shutdown: HIGH
     initial: HIGH
-    provider: pigpio-digital-output
+    provider: ffm-digital-output
   motor-pin-2:
     name: Motor Pin 2
     address: 27
     shutdown: LOW
     initial: LOW
-    provider: pigpio-digital-output
+    provider: ffm-digital-output
 ----
 
 ===== Constructor and Methods

--- a/pi4micronaut-utils/src/docs/asciidoc/components/outputComponents/passivebuzzer.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/outputComponents/passivebuzzer.adoc
@@ -96,7 +96,7 @@ pwm:
     name: passive-buzzer
     address: 17
     pwmType: SOFTWARE
-    provider: pigpio-pwm
+    provider: ffm-pwm
     initial: 0
     shutdown: 0
 ----

--- a/pi4micronaut-utils/src/docs/asciidoc/components/outputComponents/rgbLed.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/outputComponents/rgbLed.adoc
@@ -102,14 +102,14 @@ multi-pwm:
     name: RGB LED
     addresses: 17, 18, 27
     pwmTypes: SOFTWARE, SOFTWARE, SOFTWARE
-    provider: pigpio-pwm
+    provider: ffm-pwm
     initials: 0, 0, 0
     shutdowns: 0, 0, 0
   rgb-led-2:
     name: RGB LED 2
     addresses: 18, 27, 22
     pwmTypes: SOFTWARE, SOFTWARE, SOFTWARE
-    provider: pigpio-pwm
+    provider: ffm-pwm
     initials: 0, 0, 0
     shutdowns: 0, 0, 0
 ----

--- a/pi4micronaut-utils/src/docs/asciidoc/components/outputComponents/servomotor.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/components/outputComponents/servomotor.adoc
@@ -87,7 +87,7 @@ pwm:
       name: Servo Motor
       address: 18
       pwmType: SOFTWARE
-      provider: pigpio-pwm
+      provider: ffm-pwm
       initial: 0
       shutdown: 0
 ----

--- a/pi4micronaut-utils/src/docs/asciidoc/introduction.adoc
+++ b/pi4micronaut-utils/src/docs/asciidoc/introduction.adoc
@@ -9,6 +9,6 @@ Welcome to the **Pi4Micronaut Documentation**!
 
 Pi4Micronaut is an Open Source Java library that utilizes the Micronaut Framework and Pi4J to streamline the process of creating custom IoT applications that require hardware connectivity to Raspberry Pi's.
 
-Pi4Micronaut doesn't work with the latest Raspberry Pi 5 because of its new architecture. Pi4J and pigpio libraries don't provide support for Pi 5 yet. Look out for the latest version of Pi4J that will work with Pi 5 in the future.
+Pi4Micronaut uses Pi4J 4.x with the Foreign Function &amp; Memory (FFM) provider, which talks to the GPIO pins through the Linux GPIO character device (gpiochip) rather than the legacy pigpio library. This modern interface works across Raspberry Pi models, including the Raspberry Pi 5, and other Linux-based single-board computers.
 
 By reading through our documentation, you will learn how to implement our library into your application.

--- a/pi4micronaut-utils/src/main/java/com/opensourcewithslu/inputdevices/RFidHelper.java
+++ b/pi4micronaut-utils/src/main/java/com/opensourcewithslu/inputdevices/RFidHelper.java
@@ -27,7 +27,7 @@ public class RFidHelper {
     public RFidHelper(SpiConfig config, int reset, Context pi4jContext)
     //end::const[]
     {
-        this.scanner = new RfidComponent(pi4jContext, reset, config.channel(), config.getBaud());
+        this.scanner = new RfidComponent(pi4jContext, reset, config.channel(), config.baud());
     }
 
     /**
@@ -39,7 +39,7 @@ public class RFidHelper {
     public RFidHelper(SpiConfig config, Context pi4jContext)
     //end::const[]
     {
-        this.scanner = new RfidComponent(pi4jContext, config.channel(), config.getBaud());
+        this.scanner = new RfidComponent(pi4jContext, config.channel(), config.baud());
     }
 
     /**

--- a/pi4micronaut-utils/src/main/java/com/opensourcewithslu/inputdevices/RFidHelper.java
+++ b/pi4micronaut-utils/src/main/java/com/opensourcewithslu/inputdevices/RFidHelper.java
@@ -27,7 +27,7 @@ public class RFidHelper {
     public RFidHelper(SpiConfig config, int reset, Context pi4jContext)
     //end::const[]
     {
-        this.scanner = new RfidComponent(pi4jContext, reset, config.getAddress(), config.getBaud());
+        this.scanner = new RfidComponent(pi4jContext, reset, config.channel(), config.getBaud());
     }
 
     /**
@@ -39,7 +39,7 @@ public class RFidHelper {
     public RFidHelper(SpiConfig config, Context pi4jContext)
     //end::const[]
     {
-        this.scanner = new RfidComponent(pi4jContext, config.getAddress(), config.getBaud());
+        this.scanner = new RfidComponent(pi4jContext, config.channel(), config.getBaud());
     }
 
     /**

--- a/pi4micronaut-utils/src/main/java/com/opensourcewithslu/outputdevices/MotorHelper.java
+++ b/pi4micronaut-utils/src/main/java/com/opensourcewithslu/outputdevices/MotorHelper.java
@@ -82,7 +82,7 @@ public class MotorHelper {
 
         log.info("Setting motor speed to {}%", speed);
 
-        motor.on(speed, FREQUENCY);
+        motor.on((int) Math.round(speed), FREQUENCY);
     }
 
     /**

--- a/pi4micronaut-utils/src/main/java/com/opensourcewithslu/outputdevices/ServoMotorHelper.java
+++ b/pi4micronaut-utils/src/main/java/com/opensourcewithslu/outputdevices/ServoMotorHelper.java
@@ -84,7 +84,7 @@ public class ServoMotorHelper {
 
         log.info("Setting servo to {} degrees, Pulse Width: {} us, Duty Cycle: {}%", angle, pulseWidth, dutyCycle);
 
-        servoMotor.on(dutyCycle, FREQUENCY);
+        servoMotor.on(Math.round(dutyCycle), FREQUENCY);
         try {
             Thread.sleep(100); // Pauses the thread to allow the servo to reach the set angle.
         } catch (InterruptedException e) {

--- a/pi4micronaut-utils/src/main/java/com/opensourcewithslu/utilities/Pi4JFactory.java
+++ b/pi4micronaut-utils/src/main/java/com/opensourcewithslu/utilities/Pi4JFactory.java
@@ -9,14 +9,6 @@ import com.pi4j.io.i2c.I2CConfig;
 import com.pi4j.io.pwm.Pwm;
 import com.pi4j.io.spi.Spi;
 import com.pi4j.io.spi.SpiConfig;
-import com.pi4j.library.pigpio.PiGpio;
-import com.pi4j.plugin.pigpio.provider.gpio.digital.PiGpioDigitalInputProvider;
-import com.pi4j.plugin.pigpio.provider.gpio.digital.PiGpioDigitalOutputProvider;
-import com.pi4j.plugin.pigpio.provider.i2c.PiGpioI2CProvider;
-import com.pi4j.plugin.pigpio.provider.pwm.PiGpioPwmProvider;
-import com.pi4j.plugin.pigpio.provider.serial.PiGpioSerialProvider;
-import com.pi4j.plugin.pigpio.provider.spi.PiGpioSpiProvider;
-import com.pi4j.plugin.raspberrypi.platform.RaspberryPiPlatform;
 import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Factory;
@@ -35,31 +27,17 @@ public class Pi4JFactory {
 
     /**
      * This creates the Pi4J Context that is used to create all the beans for the individual components.
+     * <p>
+     * The context is built with {@link Pi4J#newAutoContext()}, which auto-detects the plugins on the
+     * classpath. With only {@code pi4j-core} and {@code pi4j-plugin-ffm} present, this registers the
+     * Foreign Function &amp; Memory (FFM) providers ({@code ffm-digital-input}, {@code ffm-digital-output},
+     * {@code ffm-pwm}, {@code ffm-i2c} and {@code ffm-spi}).
      * @return A Pi4J Context
      */
     @Singleton
     @Bean(preDestroy = "shutdown")
     public com.pi4j.context.Context createPi4jContext() {
-        final var piGpio = PiGpio.newNativeInstance();
-
-        // Build Pi4J context with this platform and PiGPIO providers
-        return Pi4J.newContextBuilder()
-                .noAutoDetect()
-                .add(
-                        PiGpioDigitalInputProvider.newInstance(piGpio),
-                        PiGpioDigitalOutputProvider.newInstance(piGpio),
-                        PiGpioPwmProvider.newInstance(piGpio),
-                        PiGpioI2CProvider.newInstance(piGpio),
-                        PiGpioSerialProvider.newInstance(piGpio),
-                        PiGpioSpiProvider.newInstance(piGpio)
-                )
-                .add(new RaspberryPiPlatform(){
-                    @Override
-                    protected String[] getProviders() {
-                        return new String[]{};
-                    }
-                })
-                .build();
+        return Pi4J.newAutoContext();
     }
 
     /**
@@ -74,7 +52,7 @@ public class Pi4JFactory {
         var outputConfigBuilder = DigitalOutput.newConfigBuilder(pi4jContext)
                 .id(config.getId())
                 .name(config.getName())
-                .address(config.getAddress())
+                .bcm(config.getAddress())
                 .shutdown(config.getShutdown())
                 .initial(config.getInitial())
                 .provider(config.getProvider());
@@ -93,7 +71,7 @@ public class Pi4JFactory {
         var inputConfigBuilder = DigitalInput.newConfigBuilder(pi4jContext)
                 .id(config.getId())
                 .name(config.getName())
-                .address(config.getAddress())
+                .bcm(config.getAddress())
                 .debounce(config.getDebounce())
                 .pull(config.getPull())
                 .provider(config.getProvider());
@@ -114,7 +92,7 @@ public class Pi4JFactory {
                 Pwm.newConfigBuilder(pi4jContext)
                     .id(config.getId())
                     .name(config.getName())
-                    .address(config.getAddress())
+                    .channel(config.getAddress())
                     .pwmType(config.getPwmType())
                     .provider(config.getProvider())
                     .initial(config.getInitial())
@@ -135,7 +113,7 @@ public class Pi4JFactory {
         return Spi.newConfigBuilder(pi4jContext)
                 .id(config.getId())
                 .name(config.getName())
-                .address(config.getChannel())
+                .channel(config.getChannel())
                 .baud(config.getBaud())
                 .build();
     }

--- a/pi4micronaut-utils/src/main/java/com/opensourcewithslu/utilities/Pi4JMultiPinFactory.java
+++ b/pi4micronaut-utils/src/main/java/com/opensourcewithslu/utilities/Pi4JMultiPinFactory.java
@@ -38,7 +38,7 @@ public class Pi4JMultiPinFactory {
             var inputConfigBuilder = DigitalInput.newConfigBuilder(pi4jContext)
                     .id(config.getId() + i)
                     .name(config.getName())
-                    .address(config.getAddresses()[i])
+                    .bcm(config.getAddresses()[i])
                     .debounce(config.getDebounces()[i])
                     .pull(config.getPulls()[i])
                     .provider(config.getProvider());
@@ -65,7 +65,7 @@ public class Pi4JMultiPinFactory {
             var pwmConfigBuilder = Pwm.newConfigBuilder(pi4jContext)
                     .id(config.getId() + i)
                     .name(config.getName())
-                    .address(config.getAddresses()[i])
+                    .channel(config.getAddresses()[i])
                     .pwmType(config.getPwmTypes()[i])
                     .initial(config.getInitials()[i])
                     .shutdown(config.getShutdowns()[i])

--- a/pi4micronaut-utils/src/test/java/com/opensourcewithslu/inputdevices/RFidHelperTest.java
+++ b/pi4micronaut-utils/src/test/java/com/opensourcewithslu/inputdevices/RFidHelperTest.java
@@ -24,8 +24,7 @@ class RFidHelperTest {
         mockContext = Mockito.mock(Context.class);
         mockSpiConfig = Mockito.mock(SpiConfig.class);
         when(mockSpiConfig.channel()).thenReturn(0);
-        when(mockSpiConfig.getBaud()).thenReturn(1_000_000);
-    }
+        when(mockSpiConfig.baud()).thenReturn(1_000_000);
 
     // Constructor creates RfidComponent when reset pin is provided
     @Test

--- a/pi4micronaut-utils/src/test/java/com/opensourcewithslu/inputdevices/RFidHelperTest.java
+++ b/pi4micronaut-utils/src/test/java/com/opensourcewithslu/inputdevices/RFidHelperTest.java
@@ -23,7 +23,7 @@ class RFidHelperTest {
     void setUp() {
         mockContext = Mockito.mock(Context.class);
         mockSpiConfig = Mockito.mock(SpiConfig.class);
-        when(mockSpiConfig.getAddress()).thenReturn(0);
+        when(mockSpiConfig.channel()).thenReturn(0);
         when(mockSpiConfig.getBaud()).thenReturn(1_000_000);
     }
 

--- a/pi4micronaut-utils/src/test/java/com/opensourcewithslu/mock/MockDigitalInput.java
+++ b/pi4micronaut-utils/src/test/java/com/opensourcewithslu/mock/MockDigitalInput.java
@@ -6,6 +6,8 @@ import com.pi4j.exception.ShutdownException;
 import com.pi4j.io.binding.DigitalBinding;
 import com.pi4j.io.gpio.digital.*;
 
+import java.util.function.Consumer;
+
 /*
 The MockDigitalInput class implements the DigitalInput interface, which requires
 all methods to be implemented, even if they are not used in the mock.
@@ -97,7 +99,21 @@ public class MockDigitalInput implements DigitalInput {
     }
 
     @Override
-    public Object shutdown(Context context) throws ShutdownException {
+    public Object shutdownInternal(Context context) throws ShutdownException {
+        return null;
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public Consumer<Boolean> addConsumer(Consumer<Boolean> listener) {
+        return listener;
+    }
+
+    @Override
+    public DigitalInput removeConsumer(Consumer<Boolean> listener) {
         return null;
     }
 }

--- a/pi4micronaut-utils/src/test/java/com/opensourcewithslu/outputdevices/MotorHelperTest.java
+++ b/pi4micronaut-utils/src/test/java/com/opensourcewithslu/outputdevices/MotorHelperTest.java
@@ -38,7 +38,7 @@ public class MotorHelperTest {
         motorHelper.enable();
         verify(log).info("Enabling DC motor");
         motorHelper.setSpeed(10);
-        verify(motor).on(10.0d, 50);
+        verify(motor).on(10, 50);
         verify(log).info("Setting motor speed to {}%", 10.0d);
     }
 
@@ -46,7 +46,7 @@ public class MotorHelperTest {
     void setSpeedFailsWhenDisabled() {
         motorHelper.setSpeed(10);
         verify(log).info("You must enable the DC motor first.");
-        verify(motor, never()).on(10.0d, 50);
+        verify(motor, never()).on(10, 50);
         verify(log, never()).info("Setting motor speed to {}%", 10);
     }
 
@@ -56,7 +56,7 @@ public class MotorHelperTest {
         verify(log).info("Enabling DC motor");
         motorHelper.setSpeed(-10);
         verify(log).info("You must enter a speed between 0 and 100.");
-        verify(motor, never()).on(-10.0d, 50);
+        verify(motor, never()).on(-10, 50);
         verify(log, never()).info("Setting speed to {}%", -10.0d);
     }
 
@@ -66,7 +66,7 @@ public class MotorHelperTest {
         verify(log).info("Enabling DC motor");
         motorHelper.setSpeed(110);
         verify(log).info("You must enter a speed between 0 and 100.");
-        verify(motor, never()).on(110.0d, 50);
+        verify(motor, never()).on(110, 50);
         verify(log, never()).info("Setting motor speed to {}%", 110.0d);
     }
 

--- a/pi4micronaut-utils/src/test/java/com/opensourcewithslu/outputdevices/ServoMotorHelperTest.java
+++ b/pi4micronaut-utils/src/test/java/com/opensourcewithslu/outputdevices/ServoMotorHelperTest.java
@@ -71,7 +71,7 @@ public class ServoMotorHelperTest {
         float pulseWidth = servoMotorHelper.map(-10);
         float dutyCycle = (pulseWidth / PWM_CYCLE_MICROSECONDS) * 100;
 
-        verify(servoMotor, never()).on(dutyCycle, FREQUENCY);
+        verify(servoMotor, never()).on(Math.round(dutyCycle), FREQUENCY);
         verify(log, never()).info("Setting angle to {} degrees", -10);
     }
 
@@ -88,7 +88,7 @@ public class ServoMotorHelperTest {
         float pulseWidth = servoMotorHelper.map(181);
         float dutyCycle = (pulseWidth / PWM_CYCLE_MICROSECONDS) * 100;
 
-        verify(servoMotor, never()).on(dutyCycle, FREQUENCY);
+        verify(servoMotor, never()).on(Math.round(dutyCycle), FREQUENCY);
         verify(log, never()).info("Setting angle to {} degrees", 181);
     }
 
@@ -105,7 +105,7 @@ public class ServoMotorHelperTest {
         float dutyCycle = (pulseWidth / PWM_CYCLE_MICROSECONDS) * 100;
 
         verify(log).info("Setting servo to {} degrees, Pulse Width: {} us, Duty Cycle: {}%", 0, pulseWidth, dutyCycle);
-        verify(servoMotor).on(dutyCycle, FREQUENCY);
+        verify(servoMotor).on(Math.round(dutyCycle), FREQUENCY);
     }
 
     @Test
@@ -125,7 +125,7 @@ public class ServoMotorHelperTest {
             throw new RuntimeException("Error running test: ", e);
         }
         verify(log).info("Setting servo to {} degrees, Pulse Width: {} us, Duty Cycle: {}%", 180, pulseWidth, dutyCycle);
-        verify(servoMotor).on(dutyCycle, FREQUENCY);
+        verify(servoMotor).on(Math.round(dutyCycle), FREQUENCY);
     }
 
     @Test
@@ -145,7 +145,7 @@ public class ServoMotorHelperTest {
             throw new RuntimeException("Error running test: ", e);
         }
         verify(log).info("Setting servo to {} degrees, Pulse Width: {} us, Duty Cycle: {}%", 90, pulseWidth, dutyCycle);
-        verify(servoMotor).on(dutyCycle, FREQUENCY);
+        verify(servoMotor).on(Math.round(dutyCycle), FREQUENCY);
     }
 
     @Test


### PR DESCRIPTION
The current README of this project mentions it can't be used on a Raspberry Pi because of Pi4J V2 limitations. But that problem has been solved already some time ago in V3. But... V4 based on Java 25 and the FFM API is even better and makes this usable on other brands of single-board computers. See https://www.pi4j.com/sbc/

This pull request bumps this project to Java 25 and Pi4J V4 but still needs to be validated on real hardware. Can this be done by one of the Pi4Micronaut maintainers, please?